### PR TITLE
Rest endpoint and player updating improvements

### DIFF
--- a/src/world/config/item-data.ts
+++ b/src/world/config/item-data.ts
@@ -61,7 +61,7 @@ export interface EquipmentBonuses {
 
 export interface ItemDetails {
     id: number;
-    desc: string;
+    desc?: string;
     canTrade: boolean;
     questItem?: boolean;
     weight?: number;
@@ -104,7 +104,6 @@ export function parseItemData(itemDefinitions: Map<number, ItemDefinition>): Map
             if(!itemDetails) {
                 itemDetails = {
                     id: itemDefinition.id,
-                    desc: itemDefinition.name,
                     canTrade: false
                 };
             }

--- a/src/world/entity/mob/walking-queue.ts
+++ b/src/world/entity/mob/walking-queue.ts
@@ -107,7 +107,7 @@ export class WalkingQueue {
         // West
         if(destination.x < initialX && destination.y == initialY) {
             if((destinationAdjacency[destinationLocalX][destinationLocalY] & 0x1280108) != 0) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move west.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move west.`);
                 return false;
             }
         }
@@ -115,7 +115,7 @@ export class WalkingQueue {
         // East
         if(destination.x > initialX && destination.y == initialY) {
             if((destinationAdjacency[destinationLocalX][destinationLocalY] & 0x1280180) != 0) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move east.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move east.`);
                 return false;
             }
         }
@@ -123,7 +123,7 @@ export class WalkingQueue {
         // South
         if(destination.y < initialY && destination.x == initialX) {
             if((destinationAdjacency[destinationLocalX][destinationLocalY] & 0x1280102) != 0) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south.`);
                 return false;
             }
         }
@@ -131,7 +131,7 @@ export class WalkingQueue {
         // North
         if(destination.y > initialY && destination.x == initialX) {
             if((destinationAdjacency[destinationLocalX][destinationLocalY] & 0x1280120) != 0) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north.`);
                 return false;
             }
         }
@@ -140,7 +140,7 @@ export class WalkingQueue {
         if(destination.x < initialX && destination.y < initialY) {
             if(!this.canMoveDiagonally(origin, destinationAdjacency, destinationLocalX, destinationLocalY, initialX, initialY, -1, -1,
                 0x128010e, 0x1280108, 0x1280102)) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south-west.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south-west.`);
                 return false;
             }
         }
@@ -149,7 +149,7 @@ export class WalkingQueue {
         if(destination.x > initialX && destination.y < initialY) {
             if(!this.canMoveDiagonally(origin, destinationAdjacency, destinationLocalX, destinationLocalY, initialX, initialY, 1, -1,
                 0x1280183, 0x1280180, 0x1280102)) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south-east.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move south-east.`);
                 return false;
             }
         }
@@ -158,7 +158,7 @@ export class WalkingQueue {
         if(destination.x < initialX && destination.y > initialY) {
             if(!this.canMoveDiagonally(origin, destinationAdjacency, destinationLocalX, destinationLocalY, initialX, initialY, -1, 1,
                 0x1280138, 0x1280108, 0x1280120)) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north-west.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north-west.`);
                 return false;
             }
         }
@@ -167,7 +167,7 @@ export class WalkingQueue {
         if(destination.x > initialX && destination.y > initialY) {
             if(!this.canMoveDiagonally(origin, destinationAdjacency, destinationLocalX, destinationLocalY, initialX, initialY, 1, 1,
                 0x12801e0, 0x1280180, 0x1280120)) {
-                logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north-east.`);
+                // logger.warn(`${this.mob instanceof Player ? this.mob.username + ' c' : 'C'}an not move north-east.`);
                 return false;
             }
         }
@@ -290,6 +290,7 @@ export class WalkingQueue {
                 const mapDiffY = this.mob.position.y - (lastMapRegionUpdatePosition.chunkY * 8);
                 if(mapDiffX < 16 || mapDiffX > 87 || mapDiffY < 16 || mapDiffY > 87) {
                     this.mob.updateFlags.mapRegionUpdateRequired = true;
+                    this.mob.lastMapRegionUpdatePosition = this.mob.position;
                 }
             }
         } else {

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -4,6 +4,7 @@ import { logger } from '@runejs/logger';
 import { ItemData, parseItemData } from './config/item-data';
 import { gameCache, world } from '../game-server';
 import { Position } from './position';
+import yargs from 'yargs';
 
 /**
  * Controls the game world and all entities within it.
@@ -39,14 +40,14 @@ export class World {
 
         const spawnChunk = this.chunkManager.getChunkForWorldPosition(new Position(x, y, 0));
 
-        for(let i = 0; i < 80; i++) {
+        for(let i = 0; i < 990; i++) {
             const player = new Player(null, null, null, i, `test${i}`, 'abs', true);
             this.registerPlayer(player);
             player.activeGameInterface = null;
 
             xOffset++;
 
-            if(xOffset > 5) {
+            if(xOffset > 20) {
                 xOffset = 0;
                 yOffset--;
             }
@@ -64,6 +65,8 @@ export class World {
     }
 
     public async worldTick(): Promise<void> {
+        let hrTime = process.hrtime();
+        const startTime = hrTime[0] * 1000000 + hrTime[1] / 1000;
         const activePlayers: Player[] = this.playerList.filter(player => player !== null);
 
         if(activePlayers.length === 0) {
@@ -76,7 +79,14 @@ export class World {
         await Promise.all(playerUpdateTasks.map(task => task.execute()));
         await Promise.all(activePlayers.map(player => player.reset()));
 
-        return Promise.resolve();
+        return Promise.resolve().then(() => {
+            let hrTime = process.hrtime();
+            const endTime = hrTime[0] * 1000000 + hrTime[1] / 1000;
+
+            if(yargs.argv.tickTime) {
+                logger.info(`World tick completed in ${endTime - startTime} microseconds.`);
+            }
+        });
     }
 
     public playerExists(player: Player): boolean {


### PR DESCRIPTION
Adding more rest endpoints for game items and giving the server the ability to chunk out new players so player updating doesn't crash with more than 80 new players being sent at a time. It also cuts off player updating in general after player 255 as the client can only handle 255 at a time.