### PR TITLE
Support for NPC and Object "selected action/option" for plugins 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 /dist
+/data/dump
 /data/saves/*.json
 
 # local env files

--- a/data/config/npc-spawns.yaml
+++ b/data/config/npc-spawns.yaml
@@ -2,3 +2,15 @@
   x: 3222
   y: 3222
   radius: 10
+- npcId: 1
+  x: 3222
+  y: 3218
+  radius: 12
+- npcId: 7
+  x: 3218
+  y: 3218
+  radius: 7
+- npcId: 11
+  x: 3222
+  y: 3220
+  radius: 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,9 +99,9 @@
       "dev": true
     },
     "@runejs/cache-parser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@runejs/cache-parser/-/cache-parser-0.2.1.tgz",
-      "integrity": "sha512-k28ySv4GMELcf3LAQjva+N5kKVVMiwugZSuT7mNj/Kfw2FaCzOkgk5UGmiJ3P55LujmxPRg/TFc9wVelYzc2NA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@runejs/cache-parser/-/cache-parser-0.2.2.tgz",
+      "integrity": "sha512-Ifl/qqtr2neS7XWGybJumERm7+yhfNJwrzPh9skl80GIsvaRHL6xdOru/8W6zba5M03ZROhVswU0HozrYj9bzA==",
       "requires": {
         "@runejs/logger": "^1.0.0",
         "seek-bzip": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "license": "GPL-3.0",
     "dependencies": {
         "@hapi/joi": "^16.1.8",
-        "@runejs/cache-parser": "^0.2.1",
+        "@runejs/cache-parser": "^0.2.2",
         "@runejs/logger": "^1.0.0",
         "bigi": "^1.4.2",
         "body-parser": "^1.19.0",

--- a/src/game-server.ts
+++ b/src/game-server.ts
@@ -12,8 +12,8 @@ import { ObjectActionPlugin, setObjectPlugins } from '@server/world/mob/player/a
 import { loadPlugins } from '@server/plugins/plugin-loader';
 
 const GAME_SERVER_PORT = 43594;
-export let gameCache;
-export let world;
+export let gameCache: GameCache;
+export let world: World;
 
 export async function injectPlugins(): Promise<void> {
     await loadPlugins<NpcActionPlugin>('npc-plugin').then(plugins => setNpcPlugins(plugins));

--- a/src/plugins/npc-plugin/hans/hans-plugin.ts
+++ b/src/plugins/npc-plugin/hans/hans-plugin.ts
@@ -1,8 +1,6 @@
 import { npcAction, NpcActionPlugin } from '@server/world/mob/player/action/npc-action';
 import { dialogueAction, DialogueEmote } from '@server/world/mob/player/action/dialogue/dialogue-action';
 
-const npcIds: number[] = [ 0 ];
-
 const action: npcAction = (player, npc) => {
     dialogueAction(player)
         .then(d => d.npc(npc, DialogueEmote.CALM_TALK_1, [ 'Welcome to RuneScape!' ]))
@@ -43,4 +41,4 @@ const action: npcAction = (player, npc) => {
         });
 };
 
-export default { npcIds, action, walkTo: true } as NpcActionPlugin;
+export default { npcIds: 0, options: 'talk-to', walkTo: true, action } as NpcActionPlugin;

--- a/src/plugins/object-plugin/doors/door-plugin.ts
+++ b/src/plugins/object-plugin/doors/door-plugin.ts
@@ -1,12 +1,7 @@
-import { Player } from '@server/world/mob/player/player';
-import { LandscapeObject } from '@runejs/cache-parser';
-import { Position } from '@server/world/position';
 import { directionData, WNES } from '@server/world/direction';
 import { world } from '@server/game-server';
 import { Chunk } from '@server/world/map/chunk';
 import { objectAction, ObjectActionPlugin } from '@server/world/mob/player/action/object-action';
-
-const objectIds = [1530, 4465, 4467, 3014, 3017, 3018, 3019, 1536, 1537, 1533, 1531, 1534, 12348];
 
 // @TODO move to yaml config
 const doors = [
@@ -50,7 +45,7 @@ const rightHingeDir: { [key: string]: string } = {
     'EAST': 'SOUTH'
 };
 
-export const action: objectAction = (player: Player, door: LandscapeObject, position: Position, cacheOriginal: boolean): void => {
+export const action: objectAction = (player, door, cacheDefinition, position, cacheOriginal): void => {
     let opening = true;
 
     let doorConfig = doors.find(d => d.closed === door.objectId);
@@ -90,4 +85,5 @@ export const action: objectAction = (player: Player, door: LandscapeObject, posi
     player.packetSender.playSound(opening ? 318 : 326, 7);
 };
 
-export default { objectIds, action, walkTo: true } as ObjectActionPlugin;
+export default { objectIds: [1530, 4465, 4467, 3014, 3017, 3018, 3019, 1536, 1537, 1533, 1531, 1534, 12348], options: [ 'open', 'close' ],
+    walkTo: true, action } as ObjectActionPlugin;

--- a/src/plugins/object-plugin/doors/double-door-plugin.ts
+++ b/src/plugins/object-plugin/doors/double-door-plugin.ts
@@ -1,13 +1,9 @@
-import { Player } from '@server/world/mob/player/player';
-import { LandscapeObject } from '@runejs/cache-parser';
 import { Position } from '@server/world/position';
 import { WNES } from '@server/world/direction';
 import { logger } from '@runejs/logger/dist/logger';
 import { world } from '@server/game-server';
 import { action as doorAction } from '@server/plugins/object-plugin/doors/door-plugin';
 import { objectAction, ObjectActionPlugin } from '@server/world/mob/player/action/object-action';
-
-const objectIds = [1519, 1516, 1517, 1520];
 
 const doubleDoors = [
     {
@@ -38,7 +34,7 @@ const openingDelta = {
     }
 };
 
-const action: objectAction = (player: Player, door: LandscapeObject, position: Position, cacheOriginal: boolean): void => {
+const action: objectAction = (player, door, cacheDefinition, position, cacheOriginal): void => {
     let doorConfig = doubleDoors.find(d => d.closed.indexOf(door.objectId) !== -1);
     let doorIds: number[];
     let opening = true;
@@ -92,8 +88,8 @@ const action: objectAction = (player: Player, door: LandscapeObject, position: P
         return;
     }
 
-    doorAction(player, door, position, cacheOriginal);
-    doorAction(player, otherDoor, otherDoorPosition, cacheOriginal);
+    doorAction(player, door, null, position, cacheOriginal);
+    doorAction(player, otherDoor, null, otherDoorPosition, cacheOriginal);
 };
 
-export default { objectIds, action, walkTo: true } as ObjectActionPlugin;
+export default { objectIds: [1519, 1516, 1517, 1520], options: [ 'open', 'close' ], walkTo: true, action } as ObjectActionPlugin;

--- a/src/plugins/object-plugin/doors/gate-plugin.ts
+++ b/src/plugins/object-plugin/doors/gate-plugin.ts
@@ -1,13 +1,9 @@
-import { Player } from '@server/world/mob/player/player';
-import { LandscapeObject } from '@runejs/cache-parser';
 import { Position } from '@server/world/position';
 import { directionData, WNES } from '@server/world/direction';
 import { logger } from '@runejs/logger/dist/logger';
 import { world } from '@server/game-server';
 import { ModifiedLandscapeObject } from '@server/world/map/landscape-object';
 import { objectAction, ObjectActionPlugin } from '@server/world/mob/player/action/object-action';
-
-const objectIds = [1551, 1553, 1552, 1554];
 
 const gates = [
     {
@@ -18,7 +14,7 @@ const gates = [
 ];
 
 // @TODO clean up this disgusting code
-const action: objectAction = (player: Player, gate: LandscapeObject, position: Position, cacheOriginal: boolean): void => {
+const action: objectAction = (player, gate, cacheDefinition, position, cacheOriginal): void => {
     if((gate as ModifiedLandscapeObject).metadata) {
         const metadata = (gate as ModifiedLandscapeObject).metadata;
 
@@ -208,4 +204,4 @@ const action: objectAction = (player: Player, gate: LandscapeObject, position: P
     }
 };
 
-export default { objectIds, action, walkTo: true } as ObjectActionPlugin;
+export default { objectIds: [1551, 1553, 1552, 1554], options: [ 'open', 'close' ], walkTo: true, action } as ObjectActionPlugin;

--- a/src/plugins/plugin-loader.ts
+++ b/src/plugins/plugin-loader.ts
@@ -1,6 +1,24 @@
 import * as fs from 'fs';
 
-const getAllFiles = function(dirPath: string, arrayOfFiles = []) {
+export const pluginFilter = (ids: number | number[], id: number, options: string | string[], option: string): boolean => {
+    if(Array.isArray(ids)) {
+        if(ids.indexOf(id) === -1) {
+            return false;
+        }
+    } else {
+        if(ids !== id) {
+            return false;
+        }
+    }
+
+    if(Array.isArray(options)) {
+        return options.indexOf(option) !== -1;
+    } else {
+        return options === option;
+    }
+};
+
+const getAllFiles = (dirPath: string, arrayOfFiles = []) => {
     const files = fs.readdirSync(dirPath);
 
     files.forEach(file => {

--- a/src/world/mob/npc/npc.ts
+++ b/src/world/mob/npc/npc.ts
@@ -24,6 +24,7 @@ export class Npc extends Mob {
     private _name: string;
     private _combatLevel: number;
     private _animations: NpcAnimations;
+    public readonly options: string[];
     private _movementRadius: number = 0;
     private _initialFaceDirection: Direction = 'NORTH';
     public readonly initialPosition: Position;
@@ -35,6 +36,7 @@ export class Npc extends Mob {
         this._name = cacheData.name;
         this._combatLevel = cacheData.combatLevel;
         this._animations = cacheData.animations as NpcAnimations;
+        this.options = cacheData.actions;
         this.position = new Position(npcSpawn.x, npcSpawn.y, npcSpawn.level);
         this.initialPosition = new Position(npcSpawn.x, npcSpawn.y, npcSpawn.level);
 

--- a/src/world/mob/player/action/input-command-action.ts
+++ b/src/world/mob/player/action/input-command-action.ts
@@ -72,7 +72,7 @@ const commands: { [key: string]: commandHandler } = {
     },
 
     npcaction: (player: Player) => {
-        npcAction(player, world.npcList[0], world.npcList[0].position);
+        npcAction(player, world.npcList[0], world.npcList[0].position, 'talk-to');
     },
 
     chati: (player: Player, args: string[]) => {

--- a/src/world/mob/player/action/object-action.ts
+++ b/src/world/mob/player/action/object-action.ts
@@ -1,21 +1,25 @@
 import { Player } from '@server/world/mob/player/player';
-import { LandscapeObject } from '@runejs/cache-parser';
+import { LandscapeObject, LandscapeObjectDefinition } from '@runejs/cache-parser';
 import { Position } from '@server/world/position';
 import { walkToAction } from '@server/world/mob/player/action/action';
+import { pluginFilter } from '@server/plugins/plugin-loader';
 
 /**
  * The definition for an object action function.
  */
-export type objectAction = (player: Player, landscapeObject: LandscapeObject, position: Position, cacheOriginal: boolean) => void;
+export type objectAction = (player: Player, landscapeObject: LandscapeObject, landscapeObjectDefinition: LandscapeObjectDefinition,
+                            position: Position, cacheOriginal: boolean) => void;
 
 /**
  * Defines an object interaction plugin.
- * A list of object ids that apply to the plugin, the action to be performed, and whether or not the player must first walk to the object.
+ * A list of object ids that apply to the plugin, the options for the object, the action to be performed,
+ * and whether or not the player must first walk to the object.
  */
 export interface ObjectActionPlugin {
-    objectIds: number[];
-    action: objectAction;
+    objectIds: number | number[];
+    options: string | string[];
     walkTo: boolean;
+    action: objectAction;
 }
 
 /**
@@ -32,12 +36,14 @@ export const setObjectPlugins = (plugins: ObjectActionPlugin[]): void => {
 };
 
 // @TODO priority and cancelling other (lower priority) actions
-export const objectAction = (player: Player, landscapeObject: LandscapeObject, position: Position, cacheOriginal: boolean): void => {
+export const objectAction = (player: Player, landscapeObject: LandscapeObject, landscapeObjectDefinition: LandscapeObjectDefinition,
+                             position: Position, option: string, cacheOriginal: boolean): void => {
     // Find all object action plugins that reference this landscape object
-    const interactionPlugins = objectInteractions.filter(plugin => plugin.objectIds.indexOf(landscapeObject.objectId) !== -1);
+    const interactionPlugins = objectInteractions.filter(plugin => pluginFilter(plugin.objectIds, landscapeObject.objectId, plugin.options, option));
 
     if(interactionPlugins.length === 0) {
-        player.packetSender.chatboxMessage(`Unhandled object interaction: ${landscapeObject.objectId} @ ${position.x},${position.y},${position.level}`);
+        player.packetSender.chatboxMessage(`Unhandled object interaction: ${option} ${landscapeObjectDefinition.name} ` +
+            `(id-${landscapeObject.objectId}) @ ${position.x},${position.y},${position.level}`);
         return;
     }
 
@@ -47,11 +53,13 @@ export const objectAction = (player: Player, landscapeObject: LandscapeObject, p
 
     // Make sure we walk to the object before running any of the walk-to plugins
     if(walkToPlugins.length !== 0) {
-        walkToAction(player, position).then(() => walkToPlugins.forEach(plugin => plugin.action(player, landscapeObject, position, cacheOriginal)));
+        walkToAction(player, position).then(() => walkToPlugins.forEach(plugin =>
+            plugin.action(player, landscapeObject, landscapeObjectDefinition, position, cacheOriginal)));
     }
 
     // Immediately run any non-walk-to plugins
     if(immediatePlugins.length !== 0) {
-        immediatePlugins.forEach(plugin => plugin.action(player, landscapeObject, position, cacheOriginal));
+        immediatePlugins.forEach(plugin =>
+            plugin.action(player, landscapeObject, landscapeObjectDefinition, position, cacheOriginal));
     }
 };

--- a/src/world/mob/player/packet/impl/npc-interaction-packet.ts
+++ b/src/world/mob/player/packet/impl/npc-interaction-packet.ts
@@ -4,9 +4,17 @@ import { RsBuffer } from '@server/net/rs-buffer';
 import { world } from '@server/game-server';
 import { World } from '@server/world/world';
 import { npcAction } from '@server/world/mob/player/action/npc-action';
+import { logger } from '@runejs/logger/dist/logger';
 
 export const npcInteractionPacket: incomingPacket = (player: Player, packetId: number, packetSize: number, packet: RsBuffer): void => {
-    const npcIndex = packet.readUnsignedShortLE();
+    const methods = {
+        67: 'readNegativeOffsetShortBE',
+        112: 'readUnsignedShortLE',
+        13: 'readNegativeOffsetShortLE',
+        42: 'readUnsignedShortLE',
+        8: 'readUnsignedShortLE'
+    };
+    const npcIndex = packet[methods[packetId]]();
 
     if(npcIndex < 0 || npcIndex > World.MAX_NPCS - 1) {
         return;
@@ -25,5 +33,29 @@ export const npcInteractionPacket: incomingPacket = (player: Player, packetId: n
         return;
     }
 
-    npcAction(player, npc, position);
+    const actions = {
+        112: 0, // Usually the Talk-to option
+        67: 1, // Usually the Attack option
+        13: 2, // Usually the Pickpocket option
+        42: 3,
+        8: 4
+    };
+
+    const actionIdx = actions[packetId];
+    let optionName = `action-${actionIdx + 1}`;
+    if(npc.options && npc.options.length >= actionIdx) {
+        if(!npc.options[actionIdx] || npc.options[actionIdx].toLowerCase() === 'hidden') {
+            // Invalid action
+            logger.error(`1: Invalid npc ${npc.id} option ${actionIdx + 1}, options: ${JSON.stringify(npc.options)}`);
+            return;
+        }
+
+        optionName = npc.options[actionIdx];
+    } else {
+        // Invalid action
+        logger.error(`2: Invalid npc ${npc.id} option ${actionIdx + 1}, options: ${JSON.stringify(npc.options)}`);
+        return;
+    }
+
+    npcAction(player, npc, position, optionName.toLowerCase());
 };

--- a/src/world/mob/player/packet/impl/object-interaction-packet.ts
+++ b/src/world/mob/player/packet/impl/object-interaction-packet.ts
@@ -2,24 +2,73 @@ import { incomingPacket } from '../incoming-packet';
 import { Player } from '../../player';
 import { RsBuffer } from '@server/net/rs-buffer';
 import { Position } from '@server/world/position';
-import { world } from '@server/game-server';
+import { gameCache, world } from '@server/game-server';
 import { objectAction } from '@server/world/mob/player/action/object-action';
+import { logger } from '@runejs/logger/dist/logger';
 
-export const objectInteractionPacket: incomingPacket = (player: Player, packetId: number, packetSize: number, packet: RsBuffer): void => {
+interface ObjectInteraction {
+    objectId: number;
+    x: number;
+    y: number;
+}
+
+const option1 = (packet: RsBuffer): ObjectInteraction => {
     const x = packet.readNegativeOffsetShortBE();
     const y = packet.readUnsignedShortLE();
-    const level = player.position.level;
     const objectId = packet.readUnsignedShortLE();
+    return { objectId, x, y };
+};
+
+const option2 = (packet: RsBuffer): ObjectInteraction => {
+    const objectId = packet.readUnsignedShortBE();
+    const x = packet.readUnsignedShortBE();
+    const y = packet.readNegativeOffsetShortBE();
+    return { objectId, x, y };
+};
+
+const option3 = (packet: RsBuffer): ObjectInteraction => {
+    const y = packet.readNegativeOffsetShortBE();
+    const objectId = packet.readUnsignedShortLE();
+    const x = packet.readNegativeOffsetShortLE();
+    return { objectId, x, y };
+};
+
+const option4 = (packet: RsBuffer): ObjectInteraction => {
+    const x = packet.readUnsignedShortBE();
+    const y = packet.readUnsignedShortLE();
+    const objectId = packet.readUnsignedShortBE();
+    return { objectId, x, y };
+};
+
+const option5 = (packet: RsBuffer): ObjectInteraction => {
+    const objectId = packet.readUnsignedShortLE();
+    const y = packet.readUnsignedShortLE();
+    const x = packet.readUnsignedShortBE();
+    return { objectId, x, y };
+};
+
+export const objectInteractionPacket: incomingPacket = (player: Player, packetId: number, packetSize: number, packet: RsBuffer): void => {
+    const options = {
+        181: { packetDef: option1, index: 0 },
+        241: { packetDef: option2, index: 1 },
+        50:  { packetDef: option3, index: 2 },
+        136: { packetDef: option4, index: 3 },
+        55:  { packetDef: option5, index: 4 },
+    };
+
+    const { objectId, x, y } = options[packetId].packetDef(packet);
+    const level = player.position.level;
+
     const objectPosition = new Position(x, y, level);
     const objectChunk = world.chunkManager.getChunkForWorldPosition(objectPosition);
     let cacheOriginal: boolean = true;
 
-    let chunkObject = objectChunk.getCacheObject(objectId, objectPosition);
-    if(!chunkObject) {
-        chunkObject = objectChunk.getAddedObject(objectId, objectPosition);
+    let landscapeObject = objectChunk.getCacheObject(objectId, objectPosition);
+    if(!landscapeObject) {
+        landscapeObject = objectChunk.getAddedObject(objectId, objectPosition);
         cacheOriginal = false;
 
-        if(!chunkObject) {
+        if(!landscapeObject) {
             return;
         }
     }
@@ -28,5 +77,23 @@ export const objectInteractionPacket: incomingPacket = (player: Player, packetId
         return;
     }
 
-    objectAction(player, chunkObject, objectPosition, cacheOriginal);
+    const landscapeObjectDefinition = gameCache.landscapeObjectDefinitions.get(objectId);
+
+    const actionIdx = options[packetId].index;
+    let optionName = `action-${actionIdx + 1}`;
+    if(landscapeObjectDefinition.options && landscapeObjectDefinition.options.length >= actionIdx) {
+        if(!landscapeObjectDefinition.options[actionIdx] || landscapeObjectDefinition.options[actionIdx].toLowerCase() === 'hidden') {
+            // Invalid action
+            logger.error(`1: Invalid object ${objectId} option ${actionIdx + 1}, options: ${JSON.stringify(landscapeObjectDefinition.options)}`);
+            return;
+        }
+
+        optionName = landscapeObjectDefinition.options[actionIdx];
+    } else {
+        // Invalid action
+        logger.error(`2: Invalid object ${objectId} option ${actionIdx + 1}, options: ${JSON.stringify(landscapeObjectDefinition.options)}`);
+        return;
+    }
+
+    objectAction(player, landscapeObject, landscapeObjectDefinition, objectPosition, optionName.toLowerCase(), cacheOriginal);
 };

--- a/src/world/mob/player/packet/incoming-packet-directory.ts
+++ b/src/world/mob/player/packet/incoming-packet-directory.ts
@@ -26,7 +26,16 @@ const packets: { [key: number]: incomingPacket } = {
     226: dialogueInteractionPacket,
 
     112: npcInteractionPacket,
+    13:  npcInteractionPacket,
+    42:  npcInteractionPacket,
+    8:   npcInteractionPacket,
+    67:  npcInteractionPacket,
+
     181: objectInteractionPacket,
+    241: objectInteractionPacket,
+    50:  objectInteractionPacket,
+    136: objectInteractionPacket,
+    55:  objectInteractionPacket,
 
     28:  walkPacket,
     213: walkPacket,


### PR DESCRIPTION
Adding clicked options to npc and object plugins, adding other object option packets, and making it so you can simply supply a single object id or npc id to plugins without wrapping it in an array. Also added cache landscape object definitions to object plugin actions so that the definitions can be easily referenced within plugins. 