### PR TITLE
add travel command

### DIFF
--- a/data/config/travel-locations-data.yaml
+++ b/data/config/travel-locations-data.yaml
@@ -1,0 +1,102 @@
+- name: Lumbridge
+  x: 3221
+  y: 3219
+- name: Al Kharid
+  x: 3293
+  y: 3184
+- name: Varrock
+  x: 3213
+  y: 3425
+- name: Barbarian Village
+  x: 3082
+  y: 3416
+- name: Edgeville
+  x: 3089
+  y: 3487
+- name: Draynor Village
+  x: 3083
+  y: 3249
+- name: Wizard's Tower
+  x: 3113
+  y: 3169
+- name: Port Sarim
+  x: 3019
+  y: 3244
+- name: Rimmington
+  x: 2956
+  y: 3209
+- name: Falador
+  x: 2965
+  y: 3383
+- name: Taverly
+  x: 2895
+  y: 3436
+- name: Burthorpe
+  x: 2898
+  y: 3544
+- name: Catherby
+  x: 2805
+  y: 3435
+- name: Seer's Village
+  x: 2730
+  y: 3485
+- name: Rellekka
+  x: 2659
+  y: 3657
+- name: Entrana
+  x: 2827
+  y: 3343
+- name: Karamja
+  x: 2917
+  y: 3175
+- name: Brimhaven
+  x: 2795
+  y: 3177
+- name: Shilo Village
+  x: 2849
+  y: 2961
+- name: Marim
+  x: 2758
+  y: 2781
+- name: Yanille
+  x: 2605
+  y: 3093
+- name: Port Khazard
+  x: 2655
+  y: 3157
+- name: Ardougne
+  x: 2663
+  y: 3305
+- name: West Ardougne
+  x: 2533
+  y: 3306
+- name: Tree Gnome Stronghold
+  x: 2450
+  y: 3422
+- name: Digsite
+  x: 3359
+  y: 3416
+- name: Canifis
+  x: 3494
+  y: 3483
+- name: Mort'ton
+  x: 3488
+  y: 3288
+- name: Port Phasmatys
+  x: 3666
+  y: 3486
+- name: Ruins of Uzer
+  x: 3482
+  y: 3090
+- name: Nardah
+  x: 3419
+  y: 2917
+- name: Sophanem
+  x: 3305
+  y: 2788
+- name: Pollnivneach
+  x: 3358
+  y: 2970
+- name: Bedabin Camp
+  x: 3169
+  y: 3034

--- a/src/plugins/commands/travel-command.ts
+++ b/src/plugins/commands/travel-command.ts
@@ -1,0 +1,30 @@
+import { ActionType, RunePlugin } from '@server/plugins/plugin';
+import { commandAction } from '@server/world/actor/player/action/input-command-action';
+import { world } from '@server/game-server';
+import { TravelLocation } from '@server/world/config/travel-locations';
+
+const action: commandAction = (details) => {
+    const { player, args } = details;
+
+    const search: string = args.search as string;
+    const location = world.travelLocations.find(search) as TravelLocation;
+
+    if (location) {
+        player.teleport(location.position);
+        player.sendLogMessage(`Welcome to ${location.name}`, details.isConsole);
+    } else {
+        player.sendLogMessage(`Unknown location ${search}`, details.isConsole);
+    }
+};
+
+export default new RunePlugin({
+    type: ActionType.COMMAND,
+    commands: [ 'travel' ],
+    args: [
+        {
+            name: 'search',
+            type: 'string'
+        }
+    ],
+    action
+});

--- a/src/world/config/travel-locations.ts
+++ b/src/world/config/travel-locations.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs';
+import { JSON_SCHEMA, safeLoad } from 'js-yaml';
+import { Position } from '@server/world/position';
+
+interface RawTravelLocation {
+    name: string;
+    x: number;
+    y: number;
+}
+
+export interface TravelLocation {
+    name: string;
+    key: string;
+    position: Position;
+}
+
+const readLocations = (): TravelLocation[] => {
+    const locationData = safeLoad(
+        readFileSync('data/config/travel-locations-data.yaml', 'utf8'),
+        { schema: JSON_SCHEMA }) as RawTravelLocation[];
+    return locationData.map((location) => {
+        return {
+            name: location.name,
+            key: location.name.toLowerCase(),
+            position: new Position(location.x, location.y, 0),
+        };
+    }) as TravelLocation[];
+};
+
+export default class TravelLocations {
+    private readonly locations: TravelLocation[];
+
+    public constructor () {
+        this.locations = readLocations();
+    }
+
+    public find (search: string): TravelLocation {
+        search = search.toLowerCase().trim();
+        for (const location of this.locations) {
+            if (location.key.indexOf(search) >= 0) {
+                return location;
+            }
+        }
+        return null;
+    }
+}

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -7,6 +7,7 @@ import { Position } from './position';
 import { NpcSpawn, parseNpcSpawns } from './config/npc-spawn';
 import { Npc } from './actor/npc/npc';
 import { parseShops, Shop } from '@server/world/config/shops';
+import TravelLocations from '@server/world/config/travel-locations';
 import Quadtree from 'quadtree-lib';
 import { timer } from 'rxjs';
 import { Actor } from '@server/world/actor/actor';
@@ -38,6 +39,7 @@ export class World {
     public readonly itemData: Map<number, ItemDetails>;
     public readonly npcSpawns: NpcSpawn[];
     public readonly shops: Shop[];
+    public readonly travelLocations: TravelLocations = new TravelLocations();
     public readonly playerTree: Quadtree<any>;
     public readonly npcTree: Quadtree<any>;
 
@@ -436,13 +438,13 @@ export class World {
     public async worldTick(): Promise<void> {
         const hrStart = Date.now();
         const activePlayers: Player[] = this.playerList.filter(player => player !== null);
-        
+
         if(activePlayers.length === 0) {
             return Promise.resolve().then(() => {
                 setTimeout(() => this.worldTick(), World.TICK_LENGTH); //TODO: subtract processing time
             });
         }
-        
+
         const activeNpcs: Npc[] = this.npcList.filter(npc => npc !== null);
 
         await Promise.all([ ...activePlayers.map(player => player.tick()), ...activeNpcs.map(npc => npc.tick()) ]);


### PR DESCRIPTION
The `travel` command allows players to travel to named destinations rather than explicit coordinates.

The `TravelLocations#find` method just takes the simple approach of finding the first location with a case-insensitive substring match. So if you want to go to `Ardougne`, just typing `ard` will actually take you to the Wizard's Tower since that's first in the list.

Could potentially make it more complicated by asking for clarification for multi-matches, but this is fine for now.