### PR TITLE
limit commands to admin players

### DIFF
--- a/src/net/inbound-packets/command-packet.js
+++ b/src/net/inbound-packets/command-packet.js
@@ -1,4 +1,5 @@
 import { inputCommandAction } from '../../world/actor/player/action/input-command-action';
+import {Rights} from "../../world/actor/player/player";
 
 const commandPacket = (player, packet) => {
     const input = packet.buffer.getString();
@@ -13,8 +14,11 @@ const commandPacket = (player, packet) => {
     const command = args[0];
 
     args.splice(0, 1);
-
-    inputCommandAction(player, command, isConsole, args);
+    if(player.rights !== Rights.ADMIN) {
+        player.sendLogMessage("You need to be an administrator to use commands.", isConsole);
+    } else {
+        inputCommandAction(player, command, isConsole, args);
+    }
 };
 
 export default [{


### PR DESCRIPTION
limits all commands to administrators (rights === 2)

if we follow what jagex does, normal players and player moderators should not have access to commands.
player moderators apply their 24h mutes with the report player interface.