### PR TITLE
Fixed error when opening quest journal

### DIFF
--- a/src/plugins/quests/quest-journal-plugin.ts
+++ b/src/plugins/quests/quest-journal-plugin.ts
@@ -6,6 +6,9 @@ import { pluginActions } from '@server/game-server';
 export const action: buttonAction = (details) => {
     const { player, buttonId } = details;
     const [questData] = pluginActions.quest.filter((quest) => quest.quest.questTabId === buttonId);
+    if(!questData) {
+        return;
+    }
     const quest = questData.quest;
 
     const [playerQuest] = player.quests.filter(

--- a/src/plugins/quests/quest-journal-plugin.ts
+++ b/src/plugins/quests/quest-journal-plugin.ts
@@ -5,17 +5,19 @@ import { pluginActions } from '@server/game-server';
 
 export const action: buttonAction = (details) => {
     const { player, buttonId } = details;
+    const [questData] = pluginActions.quest.filter((quest) => quest.quest.questTabId === buttonId);
+    const quest = questData.quest;
 
-    const quests = pluginActions.quest;
-    const questData = quests[Object.keys(quests).filter(questKey => quests[questKey].questTabId === buttonId)[0]];
-    const playerQuest = player.quests.find(quest => quest.questId === questData.id);
-    let playerStage = 'NOT_STARTED';
+    const [playerQuest] = player.quests.filter(
+    (playerQuest) => playerQuest.questId === quest.questTabId
+    );
 
-    if(playerQuest && playerQuest.stage) {
-        playerStage = playerQuest.stage;
+    let playerStage = "NOT_STARTED";
+    if (playerQuest && playerQuest.stage) {
+    playerStage = playerQuest.stage;
     }
 
-    let stageText = questData.stages[playerStage];
+    let stageText = quest.stages[playerStage];
     let color = 128;
 
     if(typeof stageText === 'function') {
@@ -32,7 +34,7 @@ export const action: buttonAction = (details) => {
         lines = [ 'Invalid Quest Stage' ];
     }
 
-    player.modifyWidget(widgets.questJournal, { childId: 2, text: '@dre@' + questData.name });
+    player.modifyWidget(widgets.questJournal, { childId: 2, text: '@dre@' + quest.name });
 
     for(let i = 0; i <= 100; i++) {
         if(i === 0) {

--- a/src/plugins/quests/quest-journal-plugin.ts
+++ b/src/plugins/quests/quest-journal-plugin.ts
@@ -9,12 +9,12 @@ export const action: buttonAction = (details) => {
     const quest = questData.quest;
 
     const [playerQuest] = player.quests.filter(
-    (playerQuest) => playerQuest.questId === quest.questTabId
+        (playerQuest) => playerQuest.questId === quest.questTabId
     );
 
     let playerStage = "NOT_STARTED";
     if (playerQuest && playerQuest.stage) {
-    playerStage = playerQuest.stage;
+        playerStage = playerQuest.stage;
     }
 
     let stageText = quest.stages[playerStage];


### PR DESCRIPTION
# Fixed error when opening quest journal
An error with the way quests were fetched from the main quest list caused an error when opening the quest journal. That has been fixed, along with adding a guard clause so the journal doesn't open if a quest does not exist yet.


Fixes [Issue 238](https://github.com/rune-js/server/issues/238)