### PR TITLE
small fix to get quests to work again

### DIFF
--- a/src/game-engine/config/index.ts
+++ b/src/game-engine/config/index.ts
@@ -8,7 +8,7 @@ import {
     loadItemConfigurations,
     translateItemConfig
 } from '@engine/config/item-config';
-import { cache, actionHookMap } from '@engine/game-server';
+import { cache, questMap } from '@engine/game-server';
 import {
     loadNpcConfigurations,
     NpcDetails,
@@ -187,8 +187,7 @@ export const findShop = (shopKey: string): Shop | null => {
 
 
 export const findQuest = (questId: string): Quest | null => {
-    const quests: Quest[] = actionHookMap.quest;
-    return quests.find(quest => quest.id.toLocaleLowerCase() === questId.toLocaleLowerCase()) || null;
+    return questMap[Object.keys(questMap).find(quest => quest.toLocaleLowerCase() === questId.toLocaleLowerCase())] || null;
 };
 
 export const findMusicTrack = (trackId: number): MusicTrack | null => {

--- a/src/game-engine/world/actor/player/player.ts
+++ b/src/game-engine/world/actor/player/player.ts
@@ -454,7 +454,7 @@ export class Player extends Actor {
   public setQuestProgress(questId: string, progress: QuestKey): void {
       const questData: Quest = findQuest(questId);
 
-      if(!questData) {
+      if (!questData) {
           logger.warn(`Quest data not found for ${questId}`);
           return;
       }
@@ -466,6 +466,7 @@ export class Player extends Actor {
       }
 
       if(playerQuest.progress === 0 && !playerQuest.complete) {
+          playerQuest.progress = progress;
           this.modifyWidget(widgets.questTab, { childId: questData.questTabId, textColor: colors.yellow });
       } else if(!playerQuest.complete && progress === 'complete') {
           playerQuest.complete = true;


### PR DESCRIPTION
the `findQuest` function was pointing to the action hooks map, but quests have their own array in each plugin now.

This fixes the function to use the questMap instead of the action hooks.

Cook's assistant was tested with this fix and fully working (great job btw)
![image](https://user-images.githubusercontent.com/6265839/111816726-752d8700-88dd-11eb-903f-ebea3ac17128.png)
