### PR TITLE
Fix quest colors being green when not started

### DIFF
--- a/src/game-engine/world/actor/player/player.ts
+++ b/src/game-engine/world/actor/player/player.ts
@@ -1002,9 +1002,17 @@ export class Player extends Actor {
         Object.keys(questMap).forEach(questKey => {
             const questData = questMap[questKey];
             const playerQuest = this.quests.find(quest => quest.questId === questData.id);
-            let color = colors.green;
-            if(playerQuest && !playerQuest.complete) {
-                color = playerQuest.progress === 0 ? colors.red : colors.yellow;
+            let color: number;
+
+            if (playerQuest?.complete) {
+                // Quest complete, regardless of progress
+                color = colors.green;
+            } else if (playerQuest?.progress > 0) {
+                // Quest in progress, not yet complete but progress is greater than 0
+                color = colors.yellow;
+            } else {
+                // Everything else failed, so quest hasn't been started yet
+                color = colors.red;
             }
 
             this.modifyWidget(widgets.questTab, { childId: questData.questTabId, textColor: color });


### PR DESCRIPTION
If a quest was registered as a plugin but the quest was not started, the quest would show green on the quest list tab.

This was because the playerQuest was null since the quest item doesn't get created on the player save, and the default value was being set to green.