### PR TITLE
Re-enable the welcome screen if enabled in config

### DIFF
--- a/src/game-engine/world/actor/player/player.ts
+++ b/src/game-engine/world/actor/player/player.ts
@@ -201,7 +201,7 @@ export class Player extends Actor {
                     multi: false
                 });
             }
-        } else if(serverConfig.showWelcome && this.savedMetadata.tutorialComplete) {
+        } else if(serverConfig.showWelcome && (!serverConfig.tutorialEnabled || this.savedMetadata.tutorialComplete)) {
             const daysSinceLogin = daysSinceLastLogin(this.loginDate);
             let loginDaysStr = '';
 


### PR DESCRIPTION
The welcome screen if statement was wrong. If you had the welcome screen enabled in the config, it would still check if you had completed the tutorial without checking if the tutorial was enabled in the first place