### PR TITLE
Updated tsconfig to include standard js/es files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
         ]
     },
     "include": [
+        "src/**/*.js",
         "src/**/*.ts",
         "src/**/*.tsx",
         "src/**/*.vue",


### PR DESCRIPTION
Fixes the issue where .js files would return the following error when opened:

> Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser. The file does not match your project config: `path/to/file.js`. The file must be included in at least one of the projects provided.eslint