### PR TITLE
Banking fixes

### DIFF
--- a/src/engine/world/items/item-container.ts
+++ b/src/engine/world/items/item-container.ts
@@ -4,7 +4,7 @@ import { filestore } from '@server/game/game-server';
 import { hasValueNotNull } from '@engine/util/data';
 import { findItem } from '@engine/config/config-handler';
 import { logger } from '@runejs/core';
-import { fromNote } from '.';
+import { fromNote } from '@engine/world/items/item';
 
 
 export interface ContainerUpdateEvent {

--- a/src/engine/world/items/item-container.ts
+++ b/src/engine/world/items/item-container.ts
@@ -4,6 +4,7 @@ import { filestore } from '@server/game/game-server';
 import { hasValueNotNull } from '@engine/util/data';
 import { findItem } from '@engine/config/config-handler';
 import { logger } from '@runejs/core';
+import { fromNote } from '.';
 
 
 export interface ContainerUpdateEvent {
@@ -308,7 +309,7 @@ export class ItemContainer {
         if(!itemDefinition) {
             throw new Error(`Item ID ${ item.itemId } not found!`);
         }
-        if(itemDefinition.stackable || everythingStacks) {
+        if(itemDefinition.stackable || everythingStacks || fromNote(item) > -1) {
             if(this.has(item.itemId)) {
                 const invItem = this.items[this.findIndex(item.itemId)];
                 return invItem.amount + item.amount <= 2147483647;

--- a/src/plugins/objects/bank/bank.plugin.ts
+++ b/src/plugins/objects/bank/bank.plugin.ts
@@ -114,7 +114,7 @@ export const withdrawItem: itemInteractionActionHandler = (details) => {
     }
 
     let itemIdToAdd: number = details.itemId;
-    let stackable = details.itemDetails.stackable;
+    let stackable: boolean = details.itemDetails.stackable;
     if (details.player.settings.bankWithdrawNoteMode) {
         const toNoteId: number = toNote(details.itemId);
         if (toNoteId > -1) {
@@ -172,11 +172,13 @@ export const withdrawItem: itemInteractionActionHandler = (details) => {
         amount: removeFromContainer(playerBank, details.itemId, countToRemove)
     };
 
-    if (stackable)
+    if (stackable) {
         playerInventory.add({ itemId: itemToAdd.itemId, amount: itemToAdd.amount });
-    else
-        for(let count = 0; count < itemToAdd.amount; count++)
+    } else {
+        for(let count = 0; count < itemToAdd.amount; count++) {
             playerInventory.add({ itemId: itemToAdd.itemId, amount: 1 });
+        }
+    }
 
     updateBankingInterface(details.player);
 };

--- a/src/plugins/objects/bank/bank.plugin.ts
+++ b/src/plugins/objects/bank/bank.plugin.ts
@@ -114,10 +114,12 @@ export const withdrawItem: itemInteractionActionHandler = (details) => {
     }
 
     let itemIdToAdd: number = details.itemId;
+    let stackable = details.itemDetails.stackable;
     if (details.player.settings.bankWithdrawNoteMode) {
         const toNoteId: number = toNote(details.itemId);
         if (toNoteId > -1) {
             itemIdToAdd = toNoteId;
+            stackable = true;
         } else {
             details.player.sendMessage('This item can not be withdrawn as a note.');
         }
@@ -154,7 +156,7 @@ export const withdrawItem: itemInteractionActionHandler = (details) => {
         countToRemove = itemAmount;
     }
 
-    if (!details.itemDetails.stackable) {
+    if (!stackable) {
         const slots = playerInventory.getOpenSlotCount();
         if (slots < countToRemove) {
             countToRemove = slots;
@@ -170,7 +172,11 @@ export const withdrawItem: itemInteractionActionHandler = (details) => {
         amount: removeFromContainer(playerBank, details.itemId, countToRemove)
     };
 
-    playerInventory.add({ itemId: itemToAdd.itemId, amount: itemToAdd.amount });
+    if (stackable)
+        playerInventory.add({ itemId: itemToAdd.itemId, amount: itemToAdd.amount });
+    else
+        for(let count = 0; count < itemToAdd.amount; count++)
+            playerInventory.add({ itemId: itemToAdd.itemId, amount: 1 });
 
     updateBankingInterface(details.player);
 };


### PR DESCRIPTION
Fix withdrawing non stackable items as stacks (closes #353)

Fix not being able to withdraw more noted items than you have space left in inventory.
_Some (maybe all) noted items were not being detected as being stackable_