### PR TITLE
fix: update player and npc damage correctly

### DIFF
--- a/src/engine/world/actor/player/sync/npc-sync-task.ts
+++ b/src/engine/world/actor/player/sync/npc-sync-task.ts
@@ -105,7 +105,7 @@ export class NpcSyncTask extends SyncTask<void> {
 
         if(updateFlags.damage !== null) {
             const damage = updateFlags.damage;
-            updateMaskData.put(damage.damageType);
+            updateMaskData.put(damage.damageDealt);
             updateMaskData.put(damage.damageType.valueOf());
             updateMaskData.put(damage.remainingHitpoints);
             updateMaskData.put(damage.maxHitpoints);

--- a/src/engine/world/actor/player/sync/player-sync-task.ts
+++ b/src/engine/world/actor/player/sync/player-sync-task.ts
@@ -139,7 +139,7 @@ export class PlayerSyncTask extends SyncTask<void> {
 
         if(updateFlags.damage !== null) {
             const damage = updateFlags.damage;
-            updateMaskData.put(damage.damageType);
+            updateMaskData.put(damage.damageDealt);
             updateMaskData.put(damage.damageType.valueOf());
             updateMaskData.put(damage.remainingHitpoints);
             updateMaskData.put(damage.maxHitpoints);


### PR DESCRIPTION
Previously the `damageDealt` was not being sent correctly