### PR TITLE
feat: add Queue<T> to `engine/util`

### DIFF
--- a/src/engine/util/index.ts
+++ b/src/engine/util/index.ts
@@ -7,3 +7,4 @@ export * from './num';
 export * from './strings';
 export * from './time';
 export * from './varbits';
+export * from './queue';

--- a/src/engine/util/queue.test.ts
+++ b/src/engine/util/queue.test.ts
@@ -1,0 +1,107 @@
+import { Queue } from './queue'
+
+describe('Queue', () => {
+    let queue: Queue<number>;
+    beforeEach(() => {
+        queue = new Queue<number>();
+    });
+
+    describe('checking Queue length', () => {
+        it('should be empty when created', () => {
+            expect(queue.isEmpty).toBe(true);
+            expect(queue.isNotEmpty).toBe(false);
+        });
+
+        it('should be not empty when an item is added', () => {
+            queue.enqueue(1);
+            expect(queue.isEmpty).toBe(false);
+            expect(queue.isNotEmpty).toBe(true);
+        });
+
+        it('should be empty when all items are removed', () => {
+            queue.enqueue(1);
+            queue.dequeue();
+            expect(queue.isEmpty).toBe(true);
+            expect(queue.isNotEmpty).toBe(false);
+        });
+
+        it('should return the correct length', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            expect(queue.length).toBe(3);
+        });
+    });
+
+    it('should return the correct items', () => {
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+        expect(queue.items).toEqual([1, 2, 3]);
+    });
+
+    describe('when peeking', () => {
+        it('should return the correct item', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            expect(queue.peek()).toBe(1);
+        });
+
+        it('should not remove the item', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            queue.peek();
+            expect(queue.items).toEqual([1, 2, 3]);
+        });
+
+        it('should return undefined when the queue is empty', () => {
+            expect(queue.peek()).toBeUndefined();
+        });
+    });
+
+    describe('when dequeuing', () => {
+        it('should return the correct item', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            expect(queue.dequeue()).toBe(1);
+        });
+
+        it('should remove the item', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            queue.dequeue();
+            expect(queue.items).toEqual([2, 3]);
+        });
+
+        it('should return undefined when the queue is empty', () => {
+            expect(queue.dequeue()).toBeUndefined();
+        });
+    });
+
+    describe('when clearing', () => {
+        it('should remove all items', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            queue.clear();
+            expect(queue.items).toEqual([]);
+        });
+    });
+
+    describe('when iterating', () => {
+        it('should iterate over all items', () => {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            const items: number[] = [];
+            for (const item of queue.items) {
+                items.push(item);
+            }
+            expect(items).toEqual([1, 2, 3]);
+        });
+    });
+})

--- a/src/engine/util/queue.ts
+++ b/src/engine/util/queue.ts
@@ -1,0 +1,67 @@
+/**
+ * A first-in-first-out queue.
+ *
+ * @author jameskmonger
+ */
+export class Queue<TItem> {
+    private _items: TItem[] = [];
+
+    /**
+     * Get the items in the queue.
+     */
+    public get items(): TItem[] {
+        return this._items;
+    }
+
+    /**
+     * Get the length of the queue.
+     */
+    public get length(): number {
+        return this._items.length;
+    }
+
+    /**
+     * Is the queue empty?
+     */
+    public get isEmpty(): boolean {
+        return this._items.length === 0;
+    }
+
+    /**
+     * Does the queue contain items?
+     */
+    public get isNotEmpty(): boolean {
+        return this._items.length > 0;
+    }
+
+    /**
+     * Add an item to the end of the queue.
+     * @param item The item to add.
+     */
+    public enqueue(item: TItem): void {
+        this._items.push(item);
+    }
+
+    /**
+     * Remove an item from the front of the queue.
+     * @returns The item removed.
+     */
+    public dequeue(): TItem {
+        return this._items.shift();
+    }
+
+    /**
+     * Get the item at the front of the queue without removing it.
+     * @returns The item at the front of the queue.
+     */
+    public peek(): TItem {
+        return this._items[0];
+    }
+
+    /**
+     * Remove all items from the queue.
+     */
+    public clear(): void {
+        this._items = [];
+    }
+}


### PR DESCRIPTION
Adds a first-in-first-out queue, needed for a future piece of work but I thought I'd raise a PR early

This would probably be a good candidate to move over to `common` at some point

```ts
const queue = new Queue<number>();

queue.enqueue(1);
queue.enqueue(2);
queue.enqueue(3);
expect(queue.dequeue()).toBe(1);
expect(queue.length).toBe(2);
```