### PR TITLE
chore: set jest to only run `**/*.test.ts` files

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -153,10 +153,9 @@ export default {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [
+    "**/*.test.ts"
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [


### PR DESCRIPTION
Jest was running compiled test files in the dist folder

These would get stale