### PR TITLE
fix: use `skills.getLevel` on player init so that modified levels are respected

### DIFF
--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -176,7 +176,7 @@ export class Player extends Actor {
         this.outgoingPackets.chatboxMessage('Welcome to RuneJS.');
 
         this.skills.values.forEach((skill, index) =>
-            this.outgoingPackets.updateSkill(index, skill.level, skill.exp));
+            this.outgoingPackets.updateSkill(index, this.skills.getLevel(index), skill.exp));
 
         this.outgoingPackets.sendUpdateAllWidgetItems(widgets.inventory, this.inventory);
         this.outgoingPackets.sendUpdateAllWidgetItems(widgets.equipment, this.equipment);


### PR DESCRIPTION
Here is a before and after of my change:

![image](https://user-images.githubusercontent.com/2037007/188736094-74088826-fc14-4f6a-8332-755d00ab9379.png)
