### PR TITLE
build: add `typecheck` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "lint:fix": "eslint --ext .ts src --fix",
         "build:watch": "babel ./src --out-dir dist --extensions \".ts,.tsx,.js\" --source-maps --watch",
         "build": "rimraf dist && babel ./src --out-dir dist --extensions \".ts,.tsx,.js\" --source-maps",
-        "test": "jest"
+        "test": "jest",
+        "typecheck": "tsc -p ./ --noEmit"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
The `build` step passes silently if there are TypeScript errors in the TypeScript files.

This will add the command `npm run typecheck` to check all types in the codebase.

We should probably add this as a CI step at some point - atm there are too many failing types to turn it on