### PR TITLE
refactor: create strongly typed `metadata` property on `Actor` and `Player`

### DIFF
--- a/src/engine/action/pipe/button.action.ts
+++ b/src/engine/action/pipe/button.action.ts
@@ -61,12 +61,6 @@ const buttonActionPipe = (player: Player, widgetId: number, buttonId: number): R
         matchingHooks = questActions;
     }
 
-    if(player.metadata.buttonListener) {
-        if(widgetId === player.metadata.buttonListener.widgetId) {
-            player.metadata.buttonListener.event.next(buttonId);
-        }
-    }
-
     if(matchingHooks.length === 0) {
         player.outgoingPackets.chatboxMessage(`Unhandled button interaction: ${widgetId}:${buttonId}`);
         return null;

--- a/src/engine/config/shop-config.ts
+++ b/src/engine/config/shop-config.ts
@@ -97,8 +97,8 @@ export class Shop {
     }
 
     public open(player: Player): void {
-        player.metadata['lastOpenedShop'] = this;
-        player.metadata['shopCloseListener'] = player.interfaceState.closed.subscribe((whatClosed: WidgetClosedEvent) => {
+        player.metadata.lastOpenedShop = this;
+        player.metadata.shopCloseListener = player.interfaceState.closed.subscribe((whatClosed: WidgetClosedEvent) => {
             if(whatClosed && whatClosed.widget && whatClosed.widget.widgetId === widgets.shop.widgetId) {
                 this.removePlayerFromShop(player);
             }
@@ -121,7 +121,7 @@ export class Shop {
 
     private updateCustomers() {
         for (const player of this.customers) {
-            if(player.metadata['lastOpenedShop'] === this) {
+            if(player.metadata.lastOpenedShop === this) {
                 player.outgoingPackets.sendUpdateAllWidgetItems(widgets.shop, this.container);
             } else {
                 this.removePlayerFromShop(player);
@@ -130,9 +130,9 @@ export class Shop {
     }
 
     private removePlayerFromShop(player: Player) {
-        if(player.metadata['lastOpenedShop'] === this) {
-            player.metadata['lastOpenedShop'] = undefined;
-            player.metadata['shopCloseListener'].unsubscribe();
+        if(player.metadata.lastOpenedShop === this) {
+            player.metadata.lastOpenedShop = undefined;
+            player.metadata.shopCloseListener.unsubscribe();
         }
         this.customers = this.customers.filter((c) => c !== player);
     }

--- a/src/engine/net/inbound-packets/item-on-object.packet.ts
+++ b/src/engine/net/inbound-packets/item-on-object.packet.ts
@@ -47,12 +47,12 @@ const itemOnObjectPacket = (player: Player, packet: PacketData) => {
         let morphIndex = -1;
         if(objectConfig.varbitId === -1) {
             if(objectConfig.configId !== -1) {
-                const configValue = player.metadata['configs'] && player.metadata['configs'][objectConfig.configId] ? player.metadata['configs'][objectConfig.configId] : 0;
+                const configValue = player.metadata.configs && player.metadata.configs[objectConfig.configId] ? player.metadata.configs[objectConfig.configId] : 0;
                 morphIndex = configValue;
 
             }
         } else {
-            morphIndex = getVarbitMorphIndex(objectConfig.varbitId, player.metadata['configs']);
+            morphIndex = getVarbitMorphIndex(objectConfig.varbitId, player.metadata.configs);
         }
         if(morphIndex !== -1) {
             objectConfig = filestore.configStore.objectStore.getObject(objectConfig.configChangeDest[morphIndex]);

--- a/src/engine/net/inbound-packets/object-interaction.packet.ts
+++ b/src/engine/net/inbound-packets/object-interaction.packet.ts
@@ -85,11 +85,11 @@ const objectInteractionPacket = (player: Player, packet: PacketData) => {
         let morphIndex = -1;
         if(objectConfig.varbitId === -1) {
             if(objectConfig.configId !== -1) {
-                morphIndex = player.metadata['configs'] && player.metadata['configs'][objectConfig.configId] ?
-                    player.metadata['configs'][objectConfig.configId] : 0;
+                morphIndex = player.metadata.configs && player.metadata.configs[objectConfig.configId] ?
+                    player.metadata.configs[objectConfig.configId] : 0;
             }
         } else {
-            morphIndex = getVarbitMorphIndex(objectConfig.varbitId, player.metadata['configs']);
+            morphIndex = getVarbitMorphIndex(objectConfig.varbitId, player.metadata.configs);
         }
         if(morphIndex !== -1) {
             objectConfig = filestore.configStore.objectStore.getObject(objectConfig.configChangeDest[morphIndex]);

--- a/src/engine/net/outbound-packet-handler.ts
+++ b/src/engine/net/outbound-packet-handler.ts
@@ -71,7 +71,7 @@ export class OutboundPacketHandler {
 
     public sendProjectile(position: Position, offsetX: number, offsetY: number, id: number, startHeight: number, endHeight: number, speed: number, lockon: number, delay: number) {
         this.updateReferencePosition(position);
-        
+
         const packet = new Packet(1);
         packet.put(0);
         packet.put(offsetY, 'byte');
@@ -85,7 +85,8 @@ export class OutboundPacketHandler {
         packet.put(16);
         packet.put(64);
         this.queue(packet);
-    } 
+    }
+
     public updateFriendStatus(friendName: string, worldId: number): void {
         const packet = new Packet(156);
         packet.put(stringToLong(friendName.toLowerCase()), 'LONG');
@@ -278,8 +279,8 @@ export class OutboundPacketHandler {
     public updateClientConfig(configId: number, value: number): void {
         let packet: Packet;
         const metadata = this.player.metadata;
-        if(!metadata['configs']) {
-            metadata['configs'] = []
+        if(!metadata.configs) {
+            metadata.configs = []
         }
         metadata.configs[configId] = value;
 

--- a/src/engine/world/actor/actor.ts
+++ b/src/engine/world/actor/actor.ts
@@ -16,6 +16,7 @@ import { Pathfinding } from './pathfinding';
 import { Attack, AttackDamageType } from './player/attack';
 import { Behavior } from './behaviors';
 import { Effect, EffectType } from './effect';
+import { ActorMetadata } from './metadata';
 
 
 export type ActorType = 'player' | 'npc';
@@ -33,7 +34,16 @@ export abstract class Actor {
     public readonly inventory: ItemContainer = new ItemContainer(28);
     public readonly bank: ItemContainer = new ItemContainer(376);
     public readonly actionPipeline = new ActionPipeline(this);
-    public readonly metadata: { [key: string]: any } = {};
+
+    /**
+     * The map of available metadata for this actor.
+     *
+     * You cannot guarantee that this will be populated with data, so you should always check for the existence of the
+     * metadata you are looking for before using it.
+     *
+     * @author jameskmonger
+     */
+    public readonly metadata: Partial<ActorMetadata> = {};
 
     /**
      * @deprecated - use new action system instead

--- a/src/engine/world/actor/actor.ts
+++ b/src/engine/world/actor/actor.ts
@@ -119,13 +119,13 @@ export abstract class Actor {
     // https://oldschool.runescape.wiki/w/Combat_level#:~:text=Calculating%20combat%20level,-Simply&text=Add%20your%20Strength%20and%20Attack,have%20your%20melee%20combat%20level.&text=Multiply%20this%20by%200.325%20and,have%20your%20magic%20combat%20level
     // https://oldschool.runescape.wiki/w/Damage_per_second/Melee#:~:text=1%20Step%20one%3A%20Calculate%20the%20effective%20strength%20level%3B,1.7%20Step%20seven%3A%20Calculate%20the%20melee%20damage%20output
     public getAttackRoll(defender): Attack {
-        
+
         //the amount of damage is random from 0 to Max
         //stance modifiers
         const _stance_defense = 3;
         const _stance_accurate = 0;
         const _stance_controlled = 1;
-        
+
         // base level
         // ToDo: calculate prayer effects
         // round decimal result calulcation up
@@ -141,7 +141,7 @@ export abstract class Actor {
 
             Effective strength level
             Multiply by(Equipment Melee Strength + 64)
-            Add 320 
+            Add 320
             Divide by 640
             Round down to nearest integer
             Multiply by gear bonus
@@ -221,7 +221,7 @@ export abstract class Actor {
         return attack;
         //+ stance modifier
     }
-    // #endregion  
+    // #endregion
 
     public damage(amount: number, damageType: DamageType = DamageType.DAMAGE) {
         const armorReduction = 0;
@@ -357,7 +357,7 @@ export abstract class Actor {
 
     public follow(target: Actor): void {
         this.face(target, false, false, false);
-        this.metadata['following'] = target;
+        this.metadata.following = target;
 
         this.moveBehind(target);
         const subscription = target.walkingQueue.movementEvent.subscribe(() => {
@@ -372,7 +372,7 @@ export abstract class Actor {
         ).subscribe(() => {
             subscription.unsubscribe();
             this.face(null);
-            delete this.metadata['following'];
+            delete this.metadata.following;
         });
     }
 
@@ -386,7 +386,7 @@ export abstract class Actor {
         if(distance <= 1) {
             return false;
         }
-        
+
         if(distance > 16) {
             this.clearFaceActor();
             this.metadata.faceActorClearedByWalking = true;
@@ -408,7 +408,7 @@ export abstract class Actor {
             return;
         }
 
-        this.metadata['tailing'] = target;
+        this.metadata.tailing = target;
 
         this.moveTo(target);
         const subscription = target.walkingQueue.movementEvent.subscribe(async () => this.moveTo(target));
@@ -419,7 +419,7 @@ export abstract class Actor {
         ).subscribe(() => {
             subscription.unsubscribe();
             this.face(null);
-            delete this.metadata['tailing'];
+            delete this.metadata.tailing;
         });
     }
 
@@ -434,8 +434,8 @@ export abstract class Actor {
             this.updateFlags.facePosition = face;
         } else if(face instanceof Actor) {
             this.updateFlags.faceActor = face;
-            this.metadata['faceActor'] = face;
-            this.metadata['faceActorClearedByWalking'] = clearedByWalking;
+            this.metadata.faceActor = face;
+            this.metadata.faceActorClearedByWalking = clearedByWalking;
 
             if(autoClear) {
                 setTimeout(() => {
@@ -451,9 +451,9 @@ export abstract class Actor {
     }
 
     public clearFaceActor(): void {
-        if(this.metadata['faceActor']) {
+        if(this.metadata.faceActor) {
             this.updateFlags.faceActor = null;
-            this.metadata['faceActor'] = undefined;
+            this.metadata.faceActor = undefined;
         }
     }
 

--- a/src/engine/world/actor/metadata.ts
+++ b/src/engine/world/actor/metadata.ts
@@ -1,0 +1,10 @@
+/**
+ * The definition of the metadata available on an {@link Actor}.
+ *
+ * You cannot guarantee that all of these properties will be present on an actor,
+ * so you should always check for their existence before using them.
+ *
+ * @author jameskmonger
+ */
+export type ActorMetadata = {
+};

--- a/src/engine/world/actor/metadata.ts
+++ b/src/engine/world/actor/metadata.ts
@@ -1,4 +1,6 @@
 import { ConstructedRegion } from '../map';
+import { Position } from '../position';
+import { Actor } from './actor';
 
 /**
  * The definition of the metadata available on an {@link Actor}.
@@ -12,9 +14,40 @@ export type ActorMetadata = {
     /**
      * The custom constructed map region for this actor.
      *
-     * TODO Should this live on Actor rather than on {@link Player}? I don't think NPCs can have a custom map.
+     * TODO (jameskmonger) Should this live on Actor rather than on {@link Player}? I don't think NPCs can have a custom map.
      */
     customMap: ConstructedRegion;
+
+    /**
+     * The player's current target position.
+     *
+     * Used within the action pipeline.
+     */
+    walkingTo: Position;
+
+    /**
+     * The actor currently being `tailed` by this actor.
+     *
+     * TODO (jameskmonger) we should delete this - only used by deleted code in the old combat plugin
+     */
+    tailing: Actor;
+
+    /**
+     * The actor currently being followed by this actor.
+     */
+    following: Actor;
+
+    /**
+     * The actor which the local actor is facing towards.
+     */
+    faceActor: Actor;
+
+    /**
+     * Whether a walk action has cleared the actor which the local actor is facing towards.
+     *
+     * TODO (jameskmonger) does this belong on this metadata?
+     */
+    faceActorClearedByWalking: boolean;
 
     /**
      * Set to true if the actor is currently teleporting.

--- a/src/engine/world/actor/metadata.ts
+++ b/src/engine/world/actor/metadata.ts
@@ -1,3 +1,5 @@
+import { ConstructedRegion } from '../map';
+
 /**
  * The definition of the metadata available on an {@link Actor}.
  *
@@ -7,4 +9,10 @@
  * @author jameskmonger
  */
 export type ActorMetadata = {
+    /**
+     * The custom constructed map region for this actor.
+     *
+     * TODO Should this live on Actor rather than on {@link Player}? I don't think NPCs can have a custom map.
+     */
+    customMap: ConstructedRegion;
 };

--- a/src/engine/world/actor/metadata.ts
+++ b/src/engine/world/actor/metadata.ts
@@ -15,4 +15,9 @@ export type ActorMetadata = {
      * TODO Should this live on Actor rather than on {@link Player}? I don't think NPCs can have a custom map.
      */
     customMap: ConstructedRegion;
+
+    /**
+     * Set to true if the actor is currently teleporting.
+     */
+    teleporting: boolean;
 };

--- a/src/engine/world/actor/player/metadata.ts
+++ b/src/engine/world/actor/player/metadata.ts
@@ -1,3 +1,4 @@
+import { Subscription } from 'rxjs';
 import { Chunk } from '@engine/world/map';
 import { Position } from '@engine/world/position';
 
@@ -29,4 +30,18 @@ export type PlayerMetadata = {
      * The player's last position before teleporting.
      */
     lastPosition: Position;
+
+    /**
+     * The player's currently open shop.
+     *
+     * TODO (jameskmonger) This is currently an instance of `Shop`. We shouldn't be storing whole instances of classes in the metadata.
+     */
+    lastOpenedShop: any;
+
+    /**
+     * A subscription to the player's "widget closed" events.
+     *
+     * Used to remove a player from a shop when they close the shop's widget.
+     */
+    shopCloseListener: Subscription;
 };

--- a/src/engine/world/actor/player/metadata.ts
+++ b/src/engine/world/actor/player/metadata.ts
@@ -13,6 +13,11 @@ import { Position } from '@engine/world/position';
  */
 export type PlayerMetadata = {
     /**
+     * The player's client configuration options (varps).
+     */
+    configs: number[];
+
+    /**
      * The player's current and previous chunks.
      */
     updateChunk: {

--- a/src/engine/world/actor/player/metadata.ts
+++ b/src/engine/world/actor/player/metadata.ts
@@ -1,6 +1,7 @@
-import { Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { Chunk } from '@engine/world/map';
 import { Position } from '@engine/world/position';
+import { LandscapeObject } from '@runejs/filestore';
 
 /**
  * The definition of the metadata directly available on a {@link Player}.
@@ -32,6 +33,15 @@ export type PlayerMetadata = {
     lastPosition: Position;
 
     /**
+     * Used to prevent the `object_interaction` pipe from running.
+     *
+     * TODO (jameskmonger) We should probably deprecate this, it seems like it's already been
+     *          replaced by the `busy` property which is itself deprecated. This is only
+     *          used in Goblin Diplomacy.
+     */
+    blockObjectInteractions: boolean;
+
+    /**
      * The player's currently open shop.
      *
      * TODO (jameskmonger) This is currently an instance of `Shop`. We shouldn't be storing whole instances of classes in the metadata.
@@ -44,4 +54,57 @@ export type PlayerMetadata = {
      * Used to remove a player from a shop when they close the shop's widget.
      */
     shopCloseListener: Subscription;
+
+    /**
+     * Allows listening to a player clicking on the tab at the specified index.
+     *
+     * The `event` property is a `Subject` that will emit a `boolean` value when the player clicks on the tab.
+     *
+     * TODO (jameskmonger) This is only used in Goblin Diplomacy. It is only present when the player is taking part
+     *                  in Goblin Displomacy.
+     */
+    tabClickEvent: {
+        tabIndex: number;
+        event: Subject<boolean>;
+    };
+
+    /**
+     * Used to process dialogue trees.
+     */
+    dialogueIndices: Record<string, number>;
+
+    /**
+     * The player's current dialogue tree.
+     *
+     * This is a `ParsedDialogueTree` type, but that type is not exported.
+     */
+    dialogueTree: any;
+
+    /**
+     * A list of custom landscape objects that have been spawned by the player.
+     *
+     * Initialised by, and used by, the `spawn-scenery` command.
+     */
+    spawnedScenery: LandscapeObject[];
+
+    /**
+     * The last custom landscape object that was spawned by the player.
+     *
+     * Used to provide `undo` functionality to the `spawn-scenery` command.
+     */
+    lastSpawnedScenery: LandscapeObject;
+
+    /**
+     * The timestamp of the last time the player lit a fire.
+     *
+     * Used to prevent the player from lighting fires too quickly.
+     *
+     * TODO (jameskmonger) this should not be using Dates for timing and will be converted in the new task system
+     */
+    lastFire: number;
+
+    /**
+     * The ID of the player's currently open skill guide.
+     */
+    activeSkillGuide: number;
 };

--- a/src/engine/world/actor/player/metadata.ts
+++ b/src/engine/world/actor/player/metadata.ts
@@ -1,3 +1,6 @@
+import { Chunk } from '@engine/world/map';
+import { Position } from '@engine/world/position';
+
 /**
  * The definition of the metadata directly available on a {@link Player}.
  *
@@ -9,4 +12,16 @@
  * @author jameskmonger
  */
 export type PlayerMetadata = {
+    /**
+     * The player's current and previous chunks.
+     */
+    updateChunk: {
+        oldChunk: Chunk;
+        newChunk: Chunk;
+    };
+
+    /**
+     * The player's last position before teleporting.
+     */
+    lastPosition: Position;
 };

--- a/src/engine/world/actor/player/metadata.ts
+++ b/src/engine/world/actor/player/metadata.ts
@@ -1,0 +1,12 @@
+/**
+ * The definition of the metadata directly available on a {@link Player}.
+ *
+ * This is a subset of the metadata available on an {@link Actor}. See {@link ActorMetadata} for more information.
+ *
+ * You cannot guarantee that all of these properties will be present on an actor,
+ * so you should always check for their existence before using them.
+ *
+ * @author jameskmonger
+ */
+export type PlayerMetadata = {
+};

--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -45,6 +45,7 @@ import { dialogue } from '../dialogue';
 import { Npc } from '../npc';
 import { combatStyles } from '../combat';
 import { SkillName } from '../skills';
+import { PlayerMetadata } from './metadata';
 
 
 export const playerOptions: { option: string, index: number, placement: 'TOP' | 'BOTTOM' }[] = [
@@ -116,6 +117,18 @@ export class Player extends Actor {
     public ignoreList: string[] = [];
     public cutscene: Cutscene = null;
     public playerEvents: EventEmitter = new EventEmitter();
+
+    /**
+     * Override the Actor's `metadata` property to provide a more specific type.
+     *
+     * You cannot guarantee that this will be populated with data, so you should always check for the existence of the
+     * metadata you are looking for before using it.
+     *
+     * The ! is used to tell the compiler that we know this property will be defined.
+     *
+     * @author jameskmonger
+     */
+    public readonly metadata!: (Actor['metadata'] & Partial<PlayerMetadata>);
 
     private readonly _socket: Socket;
     private readonly _inCipher: Isaac;

--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -429,16 +429,16 @@ export class Player extends Actor {
 
             this.outgoingPackets.flushQueue();
 
-            if(this.metadata['updateChunk']) {
-                const { newChunk, oldChunk } = this.metadata['updateChunk'];
+            if(this.metadata.updateChunk) {
+                const { newChunk, oldChunk } = this.metadata.updateChunk;
                 oldChunk.removePlayer(this);
                 newChunk.addPlayer(this);
                 this.chunkChanged(newChunk);
-                this.metadata['updateChunk'] = null;
+                this.metadata.updateChunk = null;
             }
 
-            if(this.metadata['teleporting']) {
-                this.metadata['teleporting'] = null;
+            if(this.metadata.teleporting) {
+                this.metadata.teleporting = null;
             }
 
             resolve();
@@ -677,9 +677,9 @@ export class Player extends Actor {
     public teleport(newPosition: Position, updateRegion: boolean = true): void {
         this.walkingQueue.clear();
         const originalPosition = this.position.copy();
-        this.metadata['lastPosition'] = originalPosition;
+        this.metadata.lastPosition = originalPosition;
         this.position = newPosition;
-        this.metadata['teleporting'] = true;
+        this.metadata.teleporting = true;
 
         this.updateFlags.mapRegionUpdateRequired = updateRegion;
         this.lastMapRegionUpdatePosition = newPosition;
@@ -690,7 +690,7 @@ export class Player extends Actor {
         if(!oldChunk.equals(newChunk)) {
             oldChunk.removePlayer(this);
             newChunk.addPlayer(this);
-            this.metadata['updateChunk'] = { newChunk, oldChunk };
+            this.metadata.updateChunk = { newChunk, oldChunk };
 
             if(updateRegion) {
                 this.actionPipeline.call('region_change', regionChangeActionFactory(

--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -1087,9 +1087,9 @@ export class Player extends Actor {
 
         let morphIndex: number;
         if (originalNpc.varbitId !== -1) {
-            morphIndex = getVarbitMorphIndex(originalNpc.varbitId, this.metadata['configs']);
+            morphIndex = getVarbitMorphIndex(originalNpc.varbitId, this.metadata.configs);
         } else if (originalNpc.settingId !== -1) {
-            morphIndex = this.metadata['configs'] && this.metadata['configs'][originalNpc.settingId] ? this.metadata['configs'][originalNpc.settingId] : 0;
+            morphIndex = this.metadata.configs && this.metadata.configs[originalNpc.settingId] ? this.metadata.configs[originalNpc.settingId] : 0;
         } else {
             logger.warn(`Tried to fetch a child NPC index, but but no varbitId or settingId were found in the NPC details. NPC: ${originalNpc.id}, childrenIDs: ${originalNpc.childrenIds}`);
             return null;

--- a/src/engine/world/actor/player/sync/actor-sync.ts
+++ b/src/engine/world/actor/player/sync/actor-sync.ts
@@ -98,7 +98,7 @@ export function syncTrackedActors(packet: Packet, playerPosition: Position, appe
 
         if(exists && nearbyActors.findIndex(m => m.actor.equals(trackedActor)) !== -1
                 && trackedActor.position.withinViewDistance(playerPosition)
-                && !trackedActor.metadata['teleporting']) {
+                && !trackedActor.metadata.teleporting) {
             appendMovement(trackedActor, packet);
             appendUpdateMaskData(trackedActor);
             existingTrackedActors.push(trackedActor);

--- a/src/engine/world/actor/player/sync/player-sync-task.ts
+++ b/src/engine/world/actor/player/sync/player-sync-task.ts
@@ -30,10 +30,10 @@ export class PlayerSyncTask extends SyncTask<void> {
 
             const updateMaskData = new ByteBuffer(5000);
 
-            if(updateFlags.mapRegionUpdateRequired || this.player.metadata['teleporting']) {
+            if(updateFlags.mapRegionUpdateRequired || this.player.metadata.teleporting) {
                 playerUpdatePacket.putBits(1, 1); // Update Required
                 playerUpdatePacket.putBits(2, 3); // Map Region changed (movement type - 0=nomove, 1=walk, 2=run, 3=mapchange
-                playerUpdatePacket.putBits(1, this.player.metadata['teleporting'] ? 1 : 0); // Whether or not the client should discard the current walking queue (1 if teleporting, 0 if not)
+                playerUpdatePacket.putBits(1, this.player.metadata.teleporting ? 1 : 0); // Whether or not the client should discard the current walking queue (1 if teleporting, 0 if not)
                 playerUpdatePacket.putBits(2, this.player.position.level); // Player Height
                 playerUpdatePacket.putBits(1, updateFlags.updateBlockRequired ? 1 : 0); // Whether or not an update flag block follows
                 playerUpdatePacket.putBits(7, this.player.position.chunkLocalX); // Player Local Chunk X

--- a/src/engine/world/actor/walking-queue.ts
+++ b/src/engine/world/actor/walking-queue.ts
@@ -213,7 +213,7 @@ export class WalkingQueue {
 
             if(!oldChunk.equals(newChunk)) {
                 if(this.actor instanceof Player) {
-                    this.actor.metadata['updateChunk'] = { newChunk, oldChunk };
+                    this.actor.metadata.updateChunk = { newChunk, oldChunk };
 
                     this.actor.actionPipeline.call('region_change', regionChangeActionFactory(
                         this.actor, originalPosition, this.actor.position));

--- a/src/engine/world/actor/walking-queue.ts
+++ b/src/engine/world/actor/walking-queue.ts
@@ -144,7 +144,7 @@ export class WalkingQueue {
 
         const walkPosition = this.queue.shift();
 
-        if(this.actor.metadata['faceActorClearedByWalking'] === undefined || this.actor.metadata['faceActorClearedByWalking']) {
+        if(this.actor.metadata.faceActorClearedByWalking === undefined || this.actor.metadata.faceActorClearedByWalking) {
             this.actor.clearFaceActor();
         }
 

--- a/src/plugins/commands/travel-back-command.plugin.ts
+++ b/src/plugins/commands/travel-back-command.plugin.ts
@@ -4,8 +4,8 @@ import { Skill } from '@engine/world/actor/skills';
 const action: commandActionHandler = (details) => {
     const { player } = details;
 
-    if (player.metadata['lastPosition']) {
-        player.teleport(player.metadata['lastPosition']);
+    if (player.metadata.lastPosition) {
+        player.teleport(player.metadata.lastPosition);
     }
 };
 

--- a/src/plugins/items/shopping/buy-from-shop.plugin.ts
+++ b/src/plugins/items/shopping/buy-from-shop.plugin.ts
@@ -19,7 +19,7 @@ export const handler: itemInteractionActionHandler = (details) => {
         return;
     }
 
-    const openedShop: Shop = player.metadata['lastOpenedShop'];
+    const openedShop = player.metadata.lastOpenedShop;
     if(!openedShop) {
         return;
     }

--- a/src/plugins/items/shopping/item-value.plugin.ts
+++ b/src/plugins/items/shopping/item-value.plugin.ts
@@ -8,7 +8,7 @@ export const shopSellValueHandler: itemInteractionActionHandler = ({ player, ite
 };
 
 export const shopPurchaseValueHandler: itemInteractionActionHandler = ({ player, itemDetails }) => {
-    const openedShop: Shop = player.metadata['lastOpenedShop'];
+    const openedShop = player.metadata.lastOpenedShop;
     if(!openedShop) {
         return;
     }

--- a/src/plugins/items/shopping/sell-to-shop.plugin.ts
+++ b/src/plugins/items/shopping/sell-to-shop.plugin.ts
@@ -12,7 +12,7 @@ export const handler: itemInteractionActionHandler = (details) => {
         return;
     }
 
-    const openedShop: Shop = player.metadata['lastOpenedShop'];
+    const openedShop = player.metadata.lastOpenedShop;
     if(!openedShop) {
         return;
     }

--- a/src/plugins/skills/firemaking.plugin.ts
+++ b/src/plugins/skills/firemaking.plugin.ts
@@ -108,13 +108,13 @@ const lightFire = (player: Player, position: Position, worldItemLog: WorldItem, 
 
     player.face(position, false);
     player.metadata.lastFire = Date.now();
-    player.metadata.busy = false;
+    player.busy = false;
 };
 
 const action: itemOnItemActionHandler = (details) => {
     const { player, usedItem, usedWithItem, usedSlot, usedWithSlot } = details;
 
-    if(player.metadata['lastFire'] && Date.now() - player.metadata['lastFire'] < 600) {
+    if(player.metadata.lastFire && Date.now() - player.metadata.lastFire < 600) {
         return;
     }
 
@@ -134,7 +134,7 @@ const action: itemOnItemActionHandler = (details) => {
     player.removeItem(removeFromSlot);
     const worldItemLog = player.instance.spawnWorldItem(log, player.position, { owner: player, expires: 300 });
 
-    if(player.metadata['lastFire'] && Date.now() - player.metadata['lastFire'] < 1200 &&
+    if(player.metadata.lastFire && Date.now() - player.metadata.lastFire < 1200 &&
         canChain(skillInfo.requiredLevel, player.skills.firemaking.level)) {
         lightFire(player, position, worldItemLog, skillInfo.experienceGained);
     } else {
@@ -151,7 +151,7 @@ const action: itemOnItemActionHandler = (details) => {
 
             if(canLightFire) {
                 loop.cancel();
-                player.metadata.busy = true;
+                player.busy = true;
                 setTimeout(() => lightFire(player, position, worldItemLog, skillInfo.experienceGained), 1200);
                 return;
             }

--- a/src/plugins/skills/skill-guides/skill-guides.plugin.ts
+++ b/src/plugins/skills/skill-guides/skill-guides.plugin.ts
@@ -62,7 +62,7 @@ function loadGuide(player: Player, guideId: number, subGuideId: number = 0, refr
         slot: 'screen',
         multi: false
     });
-    player.metadata['activeSkillGuide'] = guideId;
+    player.metadata.activeSkillGuide = guideId;
 }
 
 export const guideHandler: buttonActionHandler = async (details) => {
@@ -82,7 +82,7 @@ export const subGuideHandler: widgetInteractionActionHandler = async (details) =
         guides = await loadSkillGuideConfigurations(skillGuidePath);
     }
 
-    const activeSkillGuide = player.metadata['activeSkillGuide'];
+    const activeSkillGuide = player.metadata.activeSkillGuide;
 
     if(!activeSkillGuide) {
         return;


### PR DESCRIPTION
- defines types for all `metadata` properties which were currently in use
- splits the `metadata` into `Actor` and `Player` -focused types
- adds documentation on the purpose of each property as well as metadata in general
- adds some TODOs for future consideration around deprecation etc

**Notes for reviewer:**
- the first commit (8dd93322de0a6ded569e94c91008b4934ebb30c4) is responsible for setting up the typed `metadata` system
- the remaining commits are for creating types
- the final commit (60cdb68f03edb138f4930b85fa95ffe57753eeae) is deleting some unused code