### PR TITLE
fix: initialise `metadata` within Player

### DIFF
--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -124,11 +124,9 @@ export class Player extends Actor {
      * You cannot guarantee that this will be populated with data, so you should always check for the existence of the
      * metadata you are looking for before using it.
      *
-     * The ! is used to tell the compiler that we know this property will be defined.
-     *
      * @author jameskmonger
      */
-    public readonly metadata!: (Actor['metadata'] & Partial<PlayerMetadata>);
+    public readonly metadata: (Actor['metadata'] & Partial<PlayerMetadata>) = {};
 
     private readonly _socket: Socket;
     private readonly _inCipher: Isaac;


### PR DESCRIPTION
Fixes an issue introduced in #376

Issue manifested as follows (reported by Raph on discord)

```
[2] [2022-09-13T01:55:22.550Z] ERROR (16960 on desktop-raph): Cannot read property 'configs' of undefined
[2]     TypeError: Cannot read property 'configs' of undefined
[2]         at OutboundPacketHandler.updateClientConfig (C:\Users\raphp\source\repos\runejs-server\src\engine\net\outbound-packet-handler.ts:282:22)
[2]         at Player.updateQuestTab (C:\Users\raphp\source\repos\runejs-server\src\engine\world\actor\player\player.ts:1166:30)
[2]         at Player.init (C:\Users\raphp\source\repos\runejs-server\src\engine\world\actor\player\player.ts:241:14)
[2]         at GatewayServer.createPlayer (C:\Users\raphp\source\repos\runejs-server\src\server\gateway\gateway-server.ts:181:22)
[2]         at GatewayServer.parseLoginServerResponse (C:\Users\raphp\source\repos\runejs-server\src\server\gateway\gateway-server.ts:130:36)
[2]         at Socket.<anonymous> (C:\Users\raphp\source\repos\runejs-server\src\server\gateway\gateway-server.ts:66:22)
[2]         at Socket.emit (events.js:400:28)
[2]         at addChunk (internal/streams/readable.js:293:12)
[2]         at readableAddChunk (internal/streams/readable.js:267:9)
[2]         at Socket.Readable.push (internal/streams/readable.js:206:10)
[2] [2022-09-13T01:55:22.552Z] INFO (16960 on desktop-raph): Connection destroyed.
[2] [2022-09-13T01:55:22.553Z] INFO (16960 on desktop-raph): raph has logged out.
```