### PR TITLE
feat: create tick-based task system

### DIFF
--- a/src/engine/task/README.md
+++ b/src/engine/task/README.md
@@ -23,3 +23,47 @@ this.taskScheduler.addTask(new class extends Task {
 ```
 
 Every two times that `taskScheduler.tick()` is called, it will run the `execute` function of your task.
+
+jkm progress notes below:
+
+## Features
+
+- Tick-based task scheduler :heavy_check_mark:
+- Delay task :heavy_check_mark:
+- Repeating task :heavy_check_mark:
+- Schedule tasks on world :heavy_check_mark:
+- Schedule tasks on players/npcs :heavy_check_mark:
+- Task stacking :heavy_check_mark:
+- Task breaking on walking :x:
+- Task delay until arriving :x:
+
+### Subtasks
+
+- Actor task :yellow_square:
+    - Handle break on move :x:
+- Actor to actor interaction task :think: :x:
+    - Handle walkto
+    - Keep track of interaction distance and stop if exceeded
+- Actor to world item interaction task :think: :x:
+    - as above
+- Actor to object interaction task :think: :x:
+    - as above (maybe need some generic Actor to entity interaction task)
+
+- world abstraction for spawnObject, removeObject, spawnItem
+
+### Content
+
+Migrate the below content to use task system
+- Health regen :x:
+- NPC movement :x:
+- Firemaking :yellow_square:
+    - logs in inventory :heavy_check_mark:
+    - logs on ground :heavy_check_mark:
+    - all log types :yellow_square:
+- Woodcutting :x:
+- Melee combat :x:
+- Home teleport :x:
+
+also don't forget
+
+- Anything @gruckion is working on :yellow_square: :wink:

--- a/src/engine/task/README.md
+++ b/src/engine/task/README.md
@@ -1,0 +1,25 @@
+# Task system
+
+This is a tick-based task system which allows for extensions of the `Task` class to be executed.
+
+Tasks can be executed after a delay, or immediately. They can also be set to repeat indefinitely or continue.
+
+## Scheduling a task
+
+You can schedule a task by registering it with the scheduler.
+
+The task in the example of below runs with an interval of `2`, i.e. it will be executed every 2 ticks.
+
+```ts
+this.taskScheduler.addTask(new class extends Task {
+    public constructor() {
+        super(2);
+    }
+
+    public execute(): void {
+        sendGlobalMessage('2 ticks');
+    }
+});
+```
+
+Every two times that `taskScheduler.tick()` is called, it will run the `execute` function of your task.

--- a/src/engine/task/README.md
+++ b/src/engine/task/README.md
@@ -1,91 +1,139 @@
 # Task system
 
-This is a tick-based task system which allows for extensions of the `Task` class to be executed.
+The task system allows you to write content which will be executed on the tick cycles of the server.
 
-Tasks can be executed after a delay, or immediately. They can also be set to repeat indefinitely or continue.
+You can configure a task to execute every `n` ticks (minimum of `1` for every tick), and you can also choose a number of other behaviours, such as whether the task should execute immediately or after a delay, as well as set to repeat indefinitely.
 
 ## Scheduling a task
 
-You can schedule a task by registering it with the scheduler.
+You can schedule a task by registering it with a `TaskScheduler`.
 
 The task in the example of below runs with an interval of `2`, i.e. it will be executed every 2 ticks.
 
 ```ts
-this.taskScheduler.addTask(new class extends Task {
+class MyTask extends Task {
     public constructor() {
         super({ interval: 2 });
     }
 
     public execute(): void {
-        sendGlobalMessage('2 ticks');
+        console.log('2 ticks');
     }
-});
+}
+
+const scheduler = new TaskScheduler();
+
+scheduler.addTask(new MyTask());
+
+scheduler.tick();
+scheduler.tick(); // '2 ticks'
 ```
 
-Every two times that `taskScheduler.tick()` is called, it will run the `execute` function of your task.
+Every two times that `scheduler.tick()` is called, it will run the `execute` function of your task.
 
-# Implementing this into RuneJS
+## Task configuration
 
-## Task System
+You can pass a `TaskConfig` object to the `Task` constructor in order to configure various aspects of your task.
 
-- Tick-based task scheduler :heavy_check_mark:
-- Delay task :heavy_check_mark:
-- Repeating task :heavy_check_mark:
-- Schedule tasks on world :heavy_check_mark:
-- Schedule tasks on players/npcs :heavy_check_mark:
-- Task stacking :heavy_check_mark:
-- Task breaking on walking :heavy_check_mark:
-- Task delay until arriving :heavy_check_mark:
+### Timing
 
-### Subtasks
+The most simple configuration option for a `Task` is the `interval` option. Your task will be executed every `interval` amount of ticks.
 
-#### Actor
+```ts
+/**
+* The number of ticks between each execution of the task.
+*/
+interval: number;
+```
 
-- Actor task :heavy_check_mark:
-    - Handle break on move :heavy_check_mark:
-- Actor to actor interaction task :think: :x:
-    - Handle walkto :x:
-    - Keep track of interaction distance and stop if exceeded :x:
-- Actor to world item interaction task :heavy_check_mark:
-    - Handle walkto :heavy_check_mark:
-    - Keep track of interaction distance and stop if exceeded :heavy_check_mark:
-- Actor to object interaction task :think: :x:
-    - (maybe need some generic Actor to entity interaction task)
-    - Handle walkto :x:
-    - Keep track of interaction distance and stop if exceeded :x:
+For example, with an interval of `1`, your task will run every tick. The default value is `1`.
 
-#### World
+### Immediate execution
 
-- World task :yellow_square:
-- Spawn game object task :x:
-- Remove game object task :x:
-- Spawn world item task :x:
-- Remove world item task :x:
+You can configure your task to execute immediately with the `immediate` option.
 
-### Content
+```ts
+/**
+* Should the task be executed on the first tick after it is added?
+*/
+immediate: boolean;
+```
+
+For example, if `immediate` is `true` and `interval` is `5`, your task will run on the 1st and 6th ticks (and so on).
+
+### Repeating
+
+You can use the `repeat` option to tell your task to run forever.
+
+```ts
+/**
+* Should the task be repeated indefinitely?
+*/
+repeat: boolean;
+```
+
+You can use `this.stop()` inside the task to stop it from repeating further.
+
+### Stacking
+
+The `stackType` and `stackGroup` properties allow you to control how your task interacts with other, similar tasks.
+
+```ts
+/**
+* How the task should be stacked with other tasks of the same stack group.
+*/
+stackType: TaskStackType;
+
+/**
+* The stack group for this task.
+*/
+stackGroup: string;
+```
+
+When `stackType` is set to `TaskStackType.NEVER`, other tasks with the same `stackGroup` will be stopped when your task is enqueued. A `stackType` of `TaskStackType.STACK` will allow your task to run with others of the same group.
+
+The default type is `TaskStackType.STACK` and the group is `TaskStackGroup.ACTION` (`'action'`)
+
+## Task Subtypes
+
+Rather than extending `Task`, there are a number of subclasses you can extend which will give you some syntactic sugar around common functionality.
+
+- `ActorTask`
+
+    This is the base task to be performed by an `Actor`. It will automatically listen to the actor's walking queue, and stop the task if it has a `breakType` of `ON_MOVE`.
+
+- `ActorWalkToTask`
+
+    This task will make an actor walk to a `Position` or `LandscapeObject` and will expose the `atDestination` property for your extended task to query. You can then begin executing your task logic.
+
+- `ActorLandscapeObjectInteractionTask`
+
+    This task extends `ActorWalkToTask` and will make an actor walk to a given `LandscapeObject`, before exposing the `landscapeObject` property for your task to use.
+
+- `ActorWorldItemInteractionTask`
+
+    This task extends `ActorWalkToTask` and will make an actor walk to a given `WorldItem`, before exposing the `worldItem` property for your task to use.
+
+# Future improvements
+
+- Stalling executions for certain tasks when interface is open
+    - should we create a `PlayerTask` to contain this behaviour? The `breakType` behaviour could be moved to this base, rather than `ActorTask`
+
+- Consider refactoring this system to use functional programming patterns. Composition should be favoured over inheritance generally, and there are some examples of future tasks which may be easier if we could compose tasks from building blocks. Consider the implementation of some task which requires both a `LandscapeObject` and a `WorldItem` - we currently would need to create some custom task which borrowed behaviour from the `ActorLandscapeObjectInteractionTask` and `ActorWorldItemInteractionTask`. TypeScript mixins could be useful here.
+
+# Content requiring conversion to task system
 
 Highest priority is to convert pieces of content which make use of the old `task` system. These are:
 
-- Magic attack :x:
-- Magic teleports :x:
-- Prayer :yellow_square:
-    - ensure that one-tick pray flicking works. Speak to @jameskmonger if you want to implement this and need guidance
-- Combat :x:
-    - this one is quite broken and may not be so easy to port across
-- Forging (smithing) :x:
-- Woodcutting :yellow_square:
-    - Time to cut :heavy_check_mark:
-    - Replace tree with treestump :yellow_square:
-    - Replace treestump with tree :yellow_square:
+- Magic attack
+- Magic teleports
+- Prayer
+- Combat
+- Forging (smithing)
+- Woodcutting
 
 The following areas will make interesting use of the task system and would serve as a good demonstration:
 
-- Health regen :x:
-- NPC movement :x:
-- Firemaking :yellow_square:
-    - logs in inventory :heavy_check_mark:
-    - logs on ground :heavy_check_mark:
-    - all log types :yellow_square:
-    - spawn ashes :x:
-
-Also any content @gruckion is working on will be using the new Task system to aid with development of the API
+- Health regen
+- NPC movement
+- Firemaking

--- a/src/engine/task/README.md
+++ b/src/engine/task/README.md
@@ -13,7 +13,7 @@ The task in the example of below runs with an interval of `2`, i.e. it will be e
 ```ts
 this.taskScheduler.addTask(new class extends Task {
     public constructor() {
-        super(2);
+        super({ interval: 2 });
     }
 
     public execute(): void {
@@ -24,9 +24,9 @@ this.taskScheduler.addTask(new class extends Task {
 
 Every two times that `taskScheduler.tick()` is called, it will run the `execute` function of your task.
 
-jkm progress notes below:
+# Implementing this into RuneJS
 
-## Features
+## Task System
 
 - Tick-based task scheduler :heavy_check_mark:
 - Delay task :heavy_check_mark:
@@ -34,36 +34,58 @@ jkm progress notes below:
 - Schedule tasks on world :heavy_check_mark:
 - Schedule tasks on players/npcs :heavy_check_mark:
 - Task stacking :heavy_check_mark:
-- Task breaking on walking :x:
-- Task delay until arriving :x:
+- Task breaking on walking :heavy_check_mark:
+- Task delay until arriving :heavy_check_mark:
 
 ### Subtasks
 
-- Actor task :yellow_square:
-    - Handle break on move :x:
-- Actor to actor interaction task :think: :x:
-    - Handle walkto
-    - Keep track of interaction distance and stop if exceeded
-- Actor to world item interaction task :think: :x:
-    - as above
-- Actor to object interaction task :think: :x:
-    - as above (maybe need some generic Actor to entity interaction task)
+#### Actor
 
-- world abstraction for spawnObject, removeObject, spawnItem
+- Actor task :heavy_check_mark:
+    - Handle break on move :heavy_check_mark:
+- Actor to actor interaction task :think: :x:
+    - Handle walkto :x:
+    - Keep track of interaction distance and stop if exceeded :x:
+- Actor to world item interaction task :heavy_check_mark:
+    - Handle walkto :heavy_check_mark:
+    - Keep track of interaction distance and stop if exceeded :heavy_check_mark:
+- Actor to object interaction task :think: :x:
+    - (maybe need some generic Actor to entity interaction task)
+    - Handle walkto :x:
+    - Keep track of interaction distance and stop if exceeded :x:
+
+#### World
+
+- World task :yellow_square:
+- Spawn game object task :x:
+- Remove game object task :x:
+- Spawn world item task :x:
+- Remove world item task :x:
 
 ### Content
 
-Migrate the below content to use task system
+Highest priority is to convert pieces of content which make use of the old `task` system. These are:
+
+- Magic attack :x:
+- Magic teleports :x:
+- Prayer :yellow_square:
+    - ensure that one-tick pray flicking works. Speak to @jameskmonger if you want to implement this and need guidance
+- Combat :x:
+    - this one is quite broken and may not be so easy to port across
+- Forging (smithing) :x:
+- Woodcutting :yellow_square:
+    - Time to cut :heavy_check_mark:
+    - Replace tree with treestump :yellow_square:
+    - Replace treestump with tree :yellow_square:
+
+The following areas will make interesting use of the task system and would serve as a good demonstration:
+
 - Health regen :x:
 - NPC movement :x:
 - Firemaking :yellow_square:
     - logs in inventory :heavy_check_mark:
     - logs on ground :heavy_check_mark:
     - all log types :yellow_square:
-- Woodcutting :x:
-- Melee combat :x:
-- Home teleport :x:
+    - spawn ashes :x:
 
-also don't forget
-
-- Anything @gruckion is working on :yellow_square: :wink:
+Also any content @gruckion is working on will be using the new Task system to aid with development of the API

--- a/src/engine/task/impl/actor-landscape-object-interaction-task.ts
+++ b/src/engine/task/impl/actor-landscape-object-interaction-task.ts
@@ -1,6 +1,6 @@
+import { LandscapeObject } from '@runejs/filestore';
 import { activeWorld, Position } from '@engine/world';
 import { Actor } from '@engine/world/actor';
-import { LandscapeObject } from '@runejs/filestore';
 import { ActorWalkToTask } from './actor-walk-to-task';
 
 /**
@@ -11,8 +11,9 @@ import { ActorWalkToTask } from './actor-walk-to-task';
  *
  * @author jameskmonger
  */
-export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor = Actor> extends ActorWalkToTask<TActor> {
+export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor = Actor> extends ActorWalkToTask<TActor, LandscapeObject> {
     private _landscapeObject: LandscapeObject;
+    private _objectPosition: Position;
 
     /**
      * Gets the {@link LandscapeObject} that this task is interacting with.
@@ -38,6 +39,19 @@ export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor =
     }
 
     /**
+     * Get the position of this task's landscape object
+     *
+     * @returns The position of this task's landscape object, or null if the landscape object is not present
+     */
+    protected get landscapeObjectPosition(): Position {
+        if (!this._landscapeObject) {
+            return null;
+        }
+
+        return this._objectPosition;
+    }
+
+    /**
      * @param actor The actor executing this task.
      * @param landscapeObject The landscape object to interact with.
      * @param sizeX The size of the LandscapeObject in the X direction.
@@ -51,7 +65,7 @@ export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor =
     ) {
         super(
             actor,
-            new Position(landscapeObject.x, landscapeObject.y, landscapeObject.level),
+            landscapeObject,
             Math.max(sizeX, sizeY)
         );
 
@@ -60,6 +74,8 @@ export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor =
             return;
         }
 
+        // create the Position here to prevent instantiating a new Position every tick
+        this._objectPosition = new Position(landscapeObject.x, landscapeObject.y, landscapeObject.level);
         this._landscapeObject = landscapeObject;
     }
 
@@ -80,7 +96,7 @@ export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor =
             return;
         }
 
-        const { object: worldObject } = activeWorld.findObjectAtLocation(this.actor, this._landscapeObject.objectId, this.destination);
+        const { object: worldObject } = activeWorld.findObjectAtLocation(this.actor, this._landscapeObject.objectId, this._objectPosition);
 
         if (!worldObject) {
             this.stop();

--- a/src/engine/task/impl/actor-landscape-object-interaction-task.ts
+++ b/src/engine/task/impl/actor-landscape-object-interaction-task.ts
@@ -1,0 +1,90 @@
+import { activeWorld, Position } from '@engine/world';
+import { Actor } from '@engine/world/actor';
+import { LandscapeObject } from '@runejs/filestore';
+import { ActorWalkToTask } from './actor-walk-to-task';
+
+/**
+ * A task for an actor to interact with a {@link LandscapeObject}.
+ *
+ * This task extends {@link ActorWalkToTask} and will walk the actor to the object.
+ * Once the actor is within range of the object, the task will expose the {@link landscapeObject} property
+ *
+ * @author jameskmonger
+ */
+export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor = Actor> extends ActorWalkToTask<TActor> {
+    private _landscapeObject: LandscapeObject;
+
+    /**
+     * Gets the {@link LandscapeObject} that this task is interacting with.
+     *
+     * @returns If the object is still present, and the actor is at the destination, the object.
+     *              Otherwise, `null`.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    protected get landscapeObject(): LandscapeObject | null {
+        // TODO (jameskmonger) consider if we want to do these checks rather than delegating to the child task
+        //                      as currently the subclass has to store it in a subclass property if it wants to use it
+        //                      without these checks
+        if (!this.atDestination) {
+            return null;
+        }
+
+        if (!this._landscapeObject) {
+            return null;
+        }
+
+        return this._landscapeObject;
+    }
+
+    /**
+     * @param actor The actor executing this task.
+     * @param landscapeObject The landscape object to interact with.
+     * @param sizeX The size of the LandscapeObject in the X direction.
+     * @param sizeY The size of the LandscapeObject in the Y direction.
+     */
+    constructor (
+        actor: TActor,
+        landscapeObject: LandscapeObject,
+        sizeX: number = 1,
+        sizeY: number = 1
+    ) {
+        super(
+            actor,
+            new Position(landscapeObject.x, landscapeObject.y, landscapeObject.level),
+            Math.max(sizeX, sizeY)
+        );
+
+        if (!landscapeObject) {
+            this.stop();
+            return;
+        }
+
+        this._landscapeObject = landscapeObject;
+    }
+
+    /**
+     * Checks for the continued presence of the {@link LandscapeObject} and stops the task if it is no longer present.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    public execute() {
+        super.execute();
+
+        if (!this.isActive || !this.atDestination) {
+            return;
+        }
+
+        if (!this._landscapeObject) {
+            this.stop();
+            return;
+        }
+
+        const { object: worldObject } = activeWorld.findObjectAtLocation(this.actor, this._landscapeObject.objectId, this.destination);
+
+        if (!worldObject) {
+            this.stop();
+            return;
+        }
+    }
+}

--- a/src/engine/task/impl/actor-task.ts
+++ b/src/engine/task/impl/actor-task.ts
@@ -1,0 +1,65 @@
+import { Subscription } from 'rxjs';
+import { Actor } from '@engine/world/actor';
+import { TaskBreakType, TaskConfig } from '../types';
+import { Task } from '../task';
+
+/**
+ * A task that is executed by an actor.
+ *
+ * If the task has a break type of ON_MOVE, the ActorTask will subscribe to the actor's
+ * movement events and will stop executing when the actor moves.
+ *
+ * @author jameskmonger
+ */
+export abstract class ActorTask<TActor extends Actor = Actor> extends Task {
+    /**
+     * A function that is called when a movement event is queued on the actor.
+     *
+     * This will be `null` if the task does not break on movement.
+     */
+    private walkingQueueSubscription: Subscription | null = null;
+
+    /**
+     * @param actor The actor executing this task.
+     * @param config The task configuration.
+     */
+    constructor(
+        protected readonly actor: TActor,
+        config?: TaskConfig
+    ) {
+        super(config);
+
+        this.listenForMovement();
+    }
+
+    /**
+     * Called when the task is stopped and unsubscribes from the actor's walking queue if necessary.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    public onStop(): void {
+        if (this.walkingQueueSubscription) {
+            this.walkingQueueSubscription.unsubscribe();
+        }
+    }
+
+    /**
+     * If required, listen to the actor's walking queue to stop the task
+     *
+     * This function uses `setImmediate` to ensure that the subscription to the
+     * walking queue is not created
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    private listenForMovement(): void {
+        if (!this.breaksOn(TaskBreakType.ON_MOVE)) {
+            return;
+        }
+
+        setImmediate(() => {
+            this.walkingQueueSubscription = this.actor.walkingQueue.movementQueued$.subscribe(() => {
+                this.stop();
+            });
+        });
+    }
+}

--- a/src/engine/task/impl/actor-walk-to-task.ts
+++ b/src/engine/task/impl/actor-walk-to-task.ts
@@ -1,3 +1,4 @@
+import { LandscapeObject } from '@runejs/filestore';
 import { Position } from '@engine/world/position';
 import { Actor } from '@engine/world/actor';
 import { TaskStackType, TaskBreakType, TaskStackGroup } from '../types';
@@ -11,7 +12,7 @@ import { ActorTask } from './actor-task';
  *
  * @author jameskmonger
  */
-export interface ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask<TActor> {
+export interface ActorWalkToTask<TActor extends Actor = Actor, TTarget extends LandscapeObject | Position = Position> extends ActorTask<TActor> {
     /**
      * An optional function that is called when the actor arrives at the destination.
      */
@@ -26,7 +27,7 @@ export interface ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask
  *
  * @author jameskmonger
  */
-export abstract class ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask<TActor> {
+export abstract class ActorWalkToTask<TActor extends Actor = Actor, TTarget extends LandscapeObject | Position = Position> extends ActorTask<TActor> {
     private _atDestination: boolean = false;
 
     /**
@@ -43,7 +44,7 @@ export abstract class ActorWalkToTask<TActor extends Actor = Actor> extends Acto
      */
     constructor (
         actor: TActor,
-        protected readonly destination: Position,
+        protected readonly destination: TTarget,
         protected readonly distance = 1,
     ) {
         super(
@@ -58,7 +59,11 @@ export abstract class ActorWalkToTask<TActor extends Actor = Actor> extends Acto
             }
         );
 
-        this.actor.pathfinding.walkTo(destination, { })
+        if(destination instanceof Position) {
+            this.actor.pathfinding.walkTo(destination, { })
+        } else {
+            this.actor.pathfinding.walkTo(new Position(destination.x, destination.y), { })
+        }
     }
 
     /**

--- a/src/engine/task/impl/actor-walk-to-task.ts
+++ b/src/engine/task/impl/actor-walk-to-task.ts
@@ -1,0 +1,105 @@
+import { Position } from '@engine/world/position';
+import { Actor } from '@engine/world/actor';
+import { TaskStackType, TaskBreakType, TaskStackGroup } from '../types';
+import { ActorTask } from './actor-task';
+
+/**
+ * This ActorWalkToTask interface allows us to merge with the ActorWalkToTask class
+ * and add optional methods to the class.
+ *
+ * There is no way to add optional methods directly to an abstract class.
+ *
+ * @author jameskmonger
+ */
+export interface ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask<TActor> {
+    /**
+     * An optional function that is called when the actor arrives at the destination.
+     */
+    onArrive?(): void;
+}
+
+/**
+ * An abstract task that will make an Actor walk to a specific position,
+ * before calling the `arrive` function and continuing execution.
+ *
+ * The task will be stopped if the adds a new movement to their walking queue.
+ *
+ * @author jameskmonger
+ */
+export abstract class ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask<TActor> {
+    private _atDestination: boolean = false;
+
+    /**
+     * `true` if the actor has arrived at the destination.
+     */
+    protected get atDestination(): boolean {
+        return this._atDestination;
+    }
+
+    /**
+     * @param actor The actor executing this task.
+     * @param destination The destination position.
+     * @param distance The distance from the destination position that the actor must be within to arrive.
+     */
+    constructor (
+        actor: TActor,
+        protected readonly destination: Position,
+        protected readonly distance = 1,
+    ) {
+        super(
+            actor,
+            {
+                interval: 1,
+                stackType: TaskStackType.NEVER,
+                stackGroup: TaskStackGroup.ACTION,
+                breakTypes: [ TaskBreakType.ON_MOVE ],
+                immediate: false,
+                repeat: true,
+            }
+        );
+
+        this.actor.pathfinding.walkTo(destination, { })
+    }
+
+    /**
+     * Every tick of the task, check if the actor has arrived at the destination.
+     *
+     * You can check `this.arrived` to see if the actor has arrived.
+     *
+     * If the actor has previously arrived at the destination, but is no longer within distance,
+     * the task will be stopped.
+     *
+     * @returns `true` if the task was stopped this tick, `false` otherwise.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    public execute() {
+        if (!this.isActive) {
+            return;
+        }
+
+        // TODO this uses actual distances rather than tile distances
+        //      is this correct?
+        const withinDistance = this.actor.position.withinInteractionDistance(this.destination, this.distance)
+
+        // the WalkToTask itself is complete when the actor has arrived at the destination
+        // execution will now continue in the extended class
+        if (this._atDestination) {
+            // TODO consider making this optional
+            if (!withinDistance) {
+                this._atDestination = false;
+                this.stop();
+            }
+
+            return;
+        }
+
+        if (withinDistance) {
+            this._atDestination = true;
+
+            if (this.onArrive) {
+                this.onArrive();
+            }
+        }
+    }
+}

--- a/src/engine/task/impl/actor-world-item-interaction-task.ts
+++ b/src/engine/task/impl/actor-world-item-interaction-task.ts
@@ -1,0 +1,79 @@
+import { WorldItem } from '@engine/world';
+import { Actor } from '../../world/actor/actor';
+import { ActorWalkToTask } from './actor-walk-to-task';
+
+/**
+ * A task for an actor to interact with a world item.
+ *
+ * This task extends {@link ActorWalkToTask} and will walk the actor to the world item.
+ * Once the actor is within range of the world item, the task will expose the {@link worldItem} property
+ *
+ * @author jameskmonger
+ */
+export abstract class ActorWorldItemInteractionTask<TActor extends Actor = Actor> extends ActorWalkToTask<TActor> {
+    private _worldItem: WorldItem;
+
+    /**
+     * Gets the world item that this task is interacting with.
+     *
+     * @returns If the world item is still present, and the actor is at the destination, the world item.
+     *              Otherwise, `null`.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    protected get worldItem(): WorldItem | null {
+        // TODO (jameskmonger) consider if we want to do these checks rather than delegating to the child task
+        //                      as currently the subclass has to store it in a subclass property if it wants to use it
+        //                      without these checks
+        if (!this.atDestination) {
+            return null;
+        }
+
+        if (!this._worldItem || this._worldItem.removed) {
+            return null;
+        }
+
+        return this._worldItem;
+    }
+
+    /**
+     * @param actor The actor executing this task.
+     * @param worldItem The world item to interact with.
+     */
+    constructor (
+        actor: TActor,
+        worldItem: WorldItem,
+    ) {
+        super(
+            actor,
+            worldItem.position,
+            1
+        );
+
+        if (!worldItem) {
+            this.stop();
+            return;
+        }
+
+        this._worldItem = worldItem;
+
+    }
+
+    /**
+     * Checks for the continued presence of the world item and stops the task if it is no longer present.
+     *
+     * TODO (jameskmonger) unit test this
+     */
+    public execute() {
+        super.execute();
+
+        if (!this.isActive || !this.atDestination) {
+            return;
+        }
+
+        if (!this._worldItem || this._worldItem.removed) {
+            this.stop();
+            return;
+        }
+    }
+}

--- a/src/engine/task/impl/index.ts
+++ b/src/engine/task/impl/index.ts
@@ -1,3 +1,4 @@
 export { ActorTask } from './actor-task'
 export { ActorWalkToTask } from './actor-walk-to-task'
 export { ActorWorldItemInteractionTask } from './actor-world-item-interaction-task'
+export { ActorLandscapeObjectInteractionTask } from './actor-landscape-object-interaction-task'

--- a/src/engine/task/impl/index.ts
+++ b/src/engine/task/impl/index.ts
@@ -1,0 +1,3 @@
+export { ActorTask } from './actor-task'
+export { ActorWalkToTask } from './actor-walk-to-task'
+export { ActorWorldItemInteractionTask } from './actor-world-item-interaction-task'

--- a/src/engine/task/index.ts
+++ b/src/engine/task/index.ts
@@ -1,0 +1,3 @@
+export { Task } from './task'
+export { TaskScheduler } from './task-scheduler'
+export { TaskStackType, TaskBreakType, TaskStackGroup, TaskConfig } from './types'

--- a/src/engine/task/task-scheduler.test.ts
+++ b/src/engine/task/task-scheduler.test.ts
@@ -1,0 +1,106 @@
+import { Task } from './task';
+import { TaskScheduler } from './task-scheduler';
+import { TaskStackType } from './types';
+import { createMockTask } from './utils/_testing';
+
+describe('TaskScheduler', () => {
+    let taskScheduler: TaskScheduler;
+    beforeEach(() => {
+        taskScheduler = new TaskScheduler();
+    });
+
+    describe('when enqueueing a task', () => {
+        let executeMock: jest.Mock;
+        let task: Task
+        beforeEach(() => {
+            ({ task, executeMock } = createMockTask());
+        });
+
+        it('should add the task to the running list when ticked', () => {
+            taskScheduler.enqueue(task);
+            taskScheduler.tick();
+            expect(executeMock).toHaveBeenCalled();
+        });
+
+        it('should not add the task to the running list until the next tick', () => {
+            taskScheduler.enqueue(task);
+            expect(executeMock).not.toHaveBeenCalled();
+        });
+
+        describe('when ticked multiple times', () => {
+            beforeEach(() => {
+                taskScheduler.enqueue(task);
+                taskScheduler.tick();
+                taskScheduler.tick();
+            });
+
+            it('should tick the task twice', () => {
+                expect(executeMock).toHaveBeenCalledTimes(2);
+            });
+        });
+
+        describe('when the task is stopped', () => {
+            beforeEach(() => {
+                taskScheduler.enqueue(task);
+                taskScheduler.tick();
+            });
+
+            it('should not tick the task after stopping', () => {
+                task.stop();
+                taskScheduler.tick();
+                expect(executeMock).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
+    describe('when enqueueing a task that cannot stack', () => {
+        const interval = 0;
+        const stackType = TaskStackType.NEVER;
+        const stackGroup = 'foo';
+
+        let firstExecuteMock: jest.Mock;
+        let firstTask: Task
+        beforeEach(() => {
+            ({ task: firstTask, executeMock: firstExecuteMock } = createMockTask(interval, stackType, stackGroup));
+        });
+
+        it('should stop any other tasks with the same stack group', () => {
+            const { task: secondTask, executeMock: secondExecuteMock } = createMockTask(interval, stackType, stackGroup);
+
+            taskScheduler.enqueue(firstTask);
+            taskScheduler.enqueue(secondTask);
+            taskScheduler.tick();
+
+            expect(firstExecuteMock).not.toHaveBeenCalled();
+            expect(secondExecuteMock).toHaveBeenCalled();
+        });
+
+        it('should not stop any other tasks with a different stack group', () => {
+            const otherStackGroup = 'bar';
+            const { task: secondTask, executeMock: secondExecuteMock } = createMockTask(interval, stackType, otherStackGroup);
+
+            taskScheduler.enqueue(firstTask);
+            taskScheduler.enqueue(secondTask);
+            taskScheduler.tick();
+
+            expect(firstExecuteMock).toHaveBeenCalled();
+            expect(secondExecuteMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('when clearing the scheduler', () => {
+        let executeMock: jest.Mock;
+        let task: Task
+        beforeEach(() => {
+            ({ task, executeMock } = createMockTask());
+        });
+
+        it('should stop all tasks', () => {
+            taskScheduler.enqueue(task);
+            taskScheduler.tick();
+            taskScheduler.clear();
+            taskScheduler.tick();
+            expect(executeMock).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/engine/task/task-scheduler.ts
+++ b/src/engine/task/task-scheduler.ts
@@ -1,0 +1,98 @@
+import { Queue } from '@engine/util/queue';
+import { Task } from './task';
+import { TaskStackType } from './types';
+
+/**
+ * A class that ticks tasks in a queue, and removes them when they are no longer active.
+ *
+ * @author jameskmonger
+ */
+export class TaskScheduler {
+    /**
+     * A queue of tasks that are waiting to be added to the running list.
+     */
+    private pendingTasks = new Queue<Task>();
+
+    /**
+     * The list of tasks that are currently running.
+     */
+    private runningTasks: Task[] = [];
+
+    /**
+     * Register any pending tasks, and tick any running tasks.
+     */
+    public tick(): void {
+        // Add any pending tasks to the running list
+        while(this.pendingTasks.isNotEmpty) {
+            const task = this.pendingTasks.dequeue();
+
+            if (!task || !task.isActive) {
+                continue;
+            }
+
+            this.runningTasks.push(task);
+        }
+
+        // Use an iterator so that we can remove tasks from the list while iterating
+        for(const [index, task] of this.runningTasks.entries()) {
+            if (!task) {
+                continue;
+            }
+
+            task.tick();
+
+            if (!task.isActive) {
+                this.runningTasks.splice(index, 1);
+            }
+        }
+    }
+
+    /**
+     * Add a task to the end of the pending queue.
+     *
+     * If the task has a stack type of `NEVER`, any other tasks in the scheduler
+     * with the same stack group will be stopped.
+     *
+     * @param task The task to add.
+     */
+    public enqueue(task: Task): void {
+        if (!task.isActive) {
+            return;
+        }
+
+        // if the task can't stack with others of a similar type, we need to stop them
+        if (task.stackType === TaskStackType.NEVER) {
+            // Use an iterator so that we can remove tasks from the list while iterating
+            for(const [index, otherTask] of this.runningTasks.entries()) {
+                if (!otherTask) {
+                    continue;
+                }
+
+                if (otherTask.stackGroup === task.stackGroup) {
+                    otherTask.stop();
+                    this.runningTasks.splice(index, 1);
+                }
+            }
+
+            for(const otherTask of this.pendingTasks.items) {
+                if (!otherTask) {
+                    continue;
+                }
+
+                if (otherTask.stackGroup === task.stackGroup) {
+                    otherTask.stop();
+                }
+            }
+        }
+
+        this.pendingTasks.enqueue(task);
+    }
+
+    /**
+     * Clear all tasks from the scheduler.
+     */
+    public clear(): void {
+        this.pendingTasks.clear();
+        this.runningTasks = [];
+    }
+}

--- a/src/engine/task/task.test.ts
+++ b/src/engine/task/task.test.ts
@@ -1,0 +1,213 @@
+import { Task } from './task'
+import { TaskStackType } from './types';
+import { createMockTask } from './utils/_testing';
+
+describe('Task', () => {
+    // stacking mechanics are tested in the scheduler
+    const stackType = TaskStackType.NEVER;
+    const stackGroup = 'foo';
+    const breakType = [];
+
+    describe('when interval is 0', () => {
+        const interval = 0;
+
+        // no point setting this to true as the interval is 0
+        const immediate = false;
+
+        let executeMock: jest.Mock;
+        let task: Task
+
+        describe('and repeat is true', () => {
+            const repeat = false;
+            beforeEach(() => {
+                ({ task, executeMock } = createMockTask(interval, stackType, stackGroup, immediate, breakType, repeat, ));
+            });
+
+            describe('when ticked once', () => {
+                beforeEach(() => {
+                    task.tick();
+                });
+
+                it('should execute twice', () => {
+                    expect(executeMock).toHaveBeenCalled();
+                });
+            });
+
+            describe('when ticked twice', () => {
+                beforeEach(() => {
+                    task.tick();
+                    task.tick();
+                });
+
+                it('should execute twice', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+        });
+
+        describe('and repeat is false', () => {
+            const repeat = false;
+            beforeEach(() => {
+                ({ task, executeMock } = createMockTask(interval, stackType, stackGroup, immediate, breakType, repeat));
+            });
+
+            describe('when ticked once', () => {
+                beforeEach(() => {
+                    task.tick();
+                });
+
+                it('should execute once', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            describe('when ticked twice', () => {
+                beforeEach(() => {
+                    task.tick();
+                    task.tick();
+                });
+
+                it('should execute once', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+        });
+    });
+
+
+    describe('when interval is 2', () => {
+        const interval = 2;
+
+        // not testing repeat here as it is tested above
+        const repeat = false;
+
+        let executeMock: jest.Mock;
+        let task: Task
+
+        describe('and immediate is true', () => {
+            const immediate = true;
+
+            beforeEach(() => {
+                ({ task, executeMock } = createMockTask(interval, stackType, stackGroup, immediate, breakType, repeat));
+            });
+
+            describe('when ticked once', () => {
+                beforeEach(() => {
+                    task.tick();
+                });
+
+                it('should execute once', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            describe('when ticked twice', () => {
+                beforeEach(() => {
+                    task.tick();
+                    task.tick();
+                });
+
+                // task will execute on ticks 1 and 3
+                it('should execute once', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+        });
+
+        describe('and immediate is false', () => {
+            const immediate = false;
+
+            beforeEach(() => {
+                ({ task, executeMock } = createMockTask(interval, stackType, stackGroup, immediate, breakType, repeat));
+            });
+
+            describe('when ticked once', () => {
+                beforeEach(() => {
+                    task.tick();
+                });
+
+                it('should not execute', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(0);
+                });
+            });
+
+            describe('when ticked twice', () => {
+                beforeEach(() => {
+                    task.tick();
+                    task.tick();
+                });
+
+                // task will execute on ticks 2 and 4
+                it('should execute once', () => {
+                    expect(executeMock).toHaveBeenCalledTimes(1);
+                });
+            });
+        });
+    });
+
+    describe('when there is an onStop callback', () => {
+        let task: Task;
+        let onStopMock: jest.Mock;
+        let executeMock: jest.Mock;
+
+        beforeEach(() => {
+            onStopMock = jest.fn();
+            executeMock = jest.fn();
+            task = new class extends Task {
+                constructor() {
+                    super();
+                }
+
+                public execute(): void {
+                    executeMock();
+                }
+
+                public onStop(): void {
+                    onStopMock();
+                }
+            }
+        });
+
+        describe('when the task is stopped', () => {
+            beforeEach(() => {
+                task.stop();
+            });
+
+            it('should call the onStop callback', () => {
+                expect(onStopMock).toHaveBeenCalled();
+            });
+
+            it('should not call the execute callback', () => {
+                expect(executeMock).not.toHaveBeenCalled();
+            });
+
+            describe('when the task is ticked', () => {
+                beforeEach(() => {
+                    task.tick();
+                });
+
+                it('should not call the onStop callback', () => {
+                    expect(onStopMock).toHaveBeenCalledTimes(1);
+                });
+
+                it('should not call the execute callback', () => {
+                    expect(executeMock).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when the task is stopped again', () => {
+                beforeEach(() => {
+                    task.stop();
+                });
+
+                it('should not call the onStop callback', () => {
+                    expect(onStopMock).toHaveBeenCalledTimes(1);
+                });
+
+                it('should not call the execute callback', () => {
+                    expect(executeMock).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+});

--- a/src/engine/task/task.ts
+++ b/src/engine/task/task.ts
@@ -1,7 +1,7 @@
 import { TaskBreakType, TaskConfig, TaskStackGroup, TaskStackType } from './types';
 
 const DEFAULT_TASK_CONFIG: Required<TaskConfig> = {
-    interval: 0,
+    interval: 1,
     stackType: TaskStackType.STACK,
     stackGroup: TaskStackGroup.ACTION,
     immediate: false,
@@ -40,12 +40,34 @@ export interface Task {
  * @author jameskmonger
  */
 export abstract class Task {
+    /**
+     * How the task should be stacked with other tasks of the same stack group.
+     */
     public readonly stackType: TaskStackType;
+
+    /**
+     * The stack group for this task.
+     */
     public readonly stackGroup: string;
+
+    /**
+     * Conditions under which the task should be broken.
+     */
     public readonly breakTypes: TaskBreakType[];
 
+    /**
+     * The number of ticks between each execution of the task.
+     */
     private interval: number;
+
+    /**
+     * The number of ticks remaining before the task is executed.
+     */
     private ticksRemaining: number;
+
+    /**
+     * Should the task be repeated indefinitely?
+     */
     private repeat: boolean;
 
     private _isActive = true;

--- a/src/engine/task/task.ts
+++ b/src/engine/task/task.ts
@@ -1,0 +1,145 @@
+import { TaskBreakType, TaskConfig, TaskStackGroup, TaskStackType } from './types';
+
+const DEFAULT_TASK_CONFIG: Required<TaskConfig> = {
+    interval: 0,
+    stackType: TaskStackType.STACK,
+    stackGroup: TaskStackGroup.ACTION,
+    immediate: false,
+    breakTypes: [],
+    repeat: true
+};
+
+function readConfigValue(key: keyof TaskConfig, config?: TaskConfig): any {
+    if (!config) {
+        return DEFAULT_TASK_CONFIG[key];
+    }
+
+    return config[key] !== undefined ? config[key] : DEFAULT_TASK_CONFIG[key];
+}
+
+/**
+ * This Task interface allows us to merge with the Task class
+ * and add optional methods to the class.
+ *
+ * There is no way to add optional methods directly to an abstract class.
+ *
+ * @author jameskmonger
+ */
+export interface Task {
+    /**
+     * A callback that is called when the task is stopped.
+     */
+    onStop?(): void;
+}
+
+/**
+ * A Task which can be ticked and executes after a specified number of ticks.
+ *
+ * The task can be configured to execute once, or repeatedly, and can also be executed immediately.
+ *
+ * @author jameskmonger
+ */
+export abstract class Task {
+    public readonly stackType: TaskStackType;
+    public readonly stackGroup: string;
+    public readonly breakTypes: TaskBreakType[];
+
+    private interval: number;
+    private ticksRemaining: number;
+    private repeat: boolean;
+
+    private _isActive = true;
+
+    /**
+     * Is the task active?
+     */
+    public get isActive(): boolean {
+        return this._isActive;
+    }
+
+    /**
+     * @param config the configuration options for the task
+     *
+     * @see TaskConfig for more information on the configuration options
+     */
+    public constructor(config?: TaskConfig) {
+        this.interval = readConfigValue('interval', config);
+        this.stackType = readConfigValue('stackType', config);
+        this.stackGroup = readConfigValue('stackGroup', config);
+
+        const immediate = readConfigValue('immediate', config);
+        this.ticksRemaining = immediate ? 0 : this.interval;
+        this.breakTypes = readConfigValue('breakTypes', config);
+        this.repeat = readConfigValue('repeat', config);
+    }
+
+    /**
+     * Whether this task breaks on the specified {@link TaskBreakType}.
+     *
+     * @param breakType the break type to check
+     *
+     * @returns true if the task breaks on the specified break type
+     */
+    public breaksOn(breakType: TaskBreakType): boolean {
+        return this.breakTypes.includes(breakType);
+    }
+
+    /**
+     * Stop the task from executing.
+     *
+     * @returns true if the task was stopped, false if the task was already stopped
+     */
+    public stop(): boolean {
+        // can't stop a task that's already stopped
+        if (!this._isActive) {
+            return false;
+        }
+
+        this._isActive = false;
+
+        if (this.onStop) {
+            this.onStop();
+        }
+
+        return true;
+    }
+
+    /**
+     * Tick the task, decrementing the number of ticks remaining.
+     *
+     * If the number of ticks remaining reaches zero, the task is executed.
+     *
+     * If the task is configured to repeat, the number of ticks remaining is reset to the interval.
+     * Otherwise, the task is stopped.
+     */
+    public tick(): void {
+        if (!this._isActive) {
+            return;
+        }
+
+        this.ticksRemaining--;
+
+        if (this.ticksRemaining <= 0) {
+            // TODO maybe track and expose executionCount to this child function
+            this.execute();
+
+            // TODO should we allow the repeat count to be specified?
+            if (this.repeat) {
+                this.ticksRemaining = this.interval;
+            } else {
+                // TODO should I be calling a public function rather than setting the private variable?
+                this.stop();
+            }
+        }
+    }
+
+    /**
+     * The task's execution logic.
+     *
+     * Ensure that you call `super.execute()` if you override this method!
+     *
+     * TODO (jameskmonger) consider some kind of workaround to enforce a super call
+     *              https://github.com/microsoft/TypeScript/issues/21388#issuecomment-360214959
+     */
+    public abstract execute(): void;
+}

--- a/src/engine/task/types.ts
+++ b/src/engine/task/types.ts
@@ -49,10 +49,33 @@ export enum TaskBreakType {
  * @author jameskmonger
  */
 export type TaskConfig = Partial<Readonly<{
+    /**
+     * How the task should be stacked with other tasks of the same stack group.
+     */
     stackType: TaskStackType;
+
+    /**
+     * The stack group for this task.
+     */
     stackGroup: string;
+
+    /**
+     * Conditions under which the task should be broken.
+     */
     breakTypes: TaskBreakType[];
+
+    /**
+     * The number of ticks between each execution of the task.
+     */
     interval: number;
+
+    /**
+     * Should the task be executed on the first tick after it is added?
+     */
     immediate: boolean;
+
+    /**
+     * Should the task be repeated indefinitely?
+     */
     repeat: boolean;
 }>>;

--- a/src/engine/task/types.ts
+++ b/src/engine/task/types.ts
@@ -1,0 +1,58 @@
+/**
+ * An enum to control the different stacking modes for tasks.
+ *
+ * @author jameskmonger
+ */
+export enum TaskStackType {
+    /**
+     * This task cannot be stacked with other tasks of the same stack group.
+     */
+    NEVER,
+
+    /**
+     * This task can be stacked with other tasks of the same stack group.
+     */
+    STACK,
+}
+
+/**
+ * An enum to control the different stack groups for tasks.
+ *
+ * When a task has a stack type of `NEVER`, other tasks with the same stack group will be cancelled.
+ *
+ * @author jameskmonger
+ */
+export enum TaskStackGroup {
+    /**
+     * An action task undertaken by an actor.
+     */
+    ACTION = 'action',
+}
+
+/**
+ * An enum to control the different breaking modes for tasks.
+ *
+ * @author jameskmonger
+ */
+export enum TaskBreakType {
+    /**
+     * This task gets stopped when the player moves
+     */
+    ON_MOVE,
+}
+
+/**
+ * The configuration options for a Task.
+ *
+ * All options are optional as they have default values.
+ *
+ * @author jameskmonger
+ */
+export type TaskConfig = Partial<Readonly<{
+    stackType: TaskStackType;
+    stackGroup: string;
+    breakTypes: TaskBreakType[];
+    interval: number;
+    immediate: boolean;
+    repeat: boolean;
+}>>;

--- a/src/engine/task/utils/_testing.ts
+++ b/src/engine/task/utils/_testing.ts
@@ -1,0 +1,31 @@
+import { Task } from '../task';
+import { TaskBreakType, TaskStackGroup, TaskStackType } from '../types';
+
+export function createMockTask(
+    interval: number = 0,
+    stackType: TaskStackType = TaskStackType.STACK,
+    stackGroup: string = TaskStackGroup.ACTION,
+    immediate: boolean = false,
+    breakTypes: TaskBreakType[] = [],
+    repeat: boolean = true
+){
+    const executeMock = jest.fn();
+    const task = new class extends Task {
+        constructor() {
+            super({
+                interval,
+                stackType,
+                stackGroup,
+                immediate,
+                breakTypes,
+                repeat
+            });
+        }
+
+        public execute(): void {
+            executeMock();
+        }
+    }
+
+    return { task, executeMock }
+}

--- a/src/engine/world/actor/actor.ts
+++ b/src/engine/world/actor/actor.ts
@@ -84,15 +84,47 @@ export abstract class Actor {
     }
 
     /**
-     * Adds a task to the actor's scheduler queue. These tasks will be stopped when the become inactive.
+     * Instantiate a task with the Actor instance and a set of arguments.
+     *
+     * @param taskClass The task class to instantiate. Must be a subclass of {@link Task}
+     * @param args The arguments to pass to the task constructor
+     *
+     * If the task has a stack type of `NEVER`, other tasks in the same {@link TaskStackGroup} will be cancelled.
+     */
+    public enqueueTask(taskClass: new (actor: Actor) => Task, ...args: never[]): void;
+    public enqueueTask<T1, T2, T3, T4, T5, T6>(taskClass: new (actor: Actor, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Task, args: [ T1, T2, T3, T4, T5, T6 ]): void;
+    public enqueueTask<T1, T2, T3, T4, T5>(taskClass: new (actor: Actor, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Task, args: [ T1, T2, T3, T4, T5 ]): void;
+    public enqueueTask<T1, T2, T3, T4>(taskClass: new (actor: Actor, arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Task, args: [ T1, T2, T3, T4 ]): void;
+    public enqueueTask<T1, T2, T3>(taskClass: new (actor: Actor, arg1: T1, arg2: T2, arg3: T3) => Task, args: [ T1, T2, T3 ]): void;
+    public enqueueTask<T1, T2>(taskClass: new (actor: Actor, arg1: T1, arg2: T2) => Task, args: [ T1, T2 ]): void;
+    public enqueueTask<T1>(taskClass: new (actor: Actor, arg1: T1) => Task, args: [ T1 ]): void;
+    public enqueueTask<T>(taskClass: new (actor: Actor, ...args: T[]) => Task, args: T[]): void {
+        if (!this.active) {
+            logger.warn(`Attempted to instantiate task for inactive actor`);
+            return;
+        }
+
+        if (args) {
+            this.enqueueBaseTask(
+                new taskClass(this, ...args)
+            );
+        } else {
+            this.enqueueBaseTask(
+                new taskClass(this)
+            );
+        }
+    }
+
+    /**
+     * Adds a task to the actor's scheduler queue. These tasks will be stopped when they become inactive.
      *
      * If the task has a stack type of `NEVER`, other tasks in the same group will be cancelled.
      *
      * @param task The task to add
      */
-    public enqueueTask(task: Task): void {
+    public enqueueBaseTask(task: Task): void {
         if (!this.active) {
-            logger.warn(`Attempted to enqueue task for logged out player`);
+            logger.warn(`Attempted to enqueue task for  inactive actor`);
             return;
         }
 

--- a/src/engine/world/actor/npc.ts
+++ b/src/engine/world/actor/npc.ts
@@ -103,6 +103,8 @@ export class Npc extends Actor {
     }
 
     public async init(): Promise<void> {
+        super.init();
+
         activeWorld.chunkManager.getChunkForWorldPosition(this.position).addNpc(this);
 
         if(this.movementRadius > 0) {
@@ -147,6 +149,7 @@ export class Npc extends Actor {
     }
 
     public kill(respawn: boolean = true): void {
+        this.destroy();
 
         activeWorld.chunkManager.getChunkForWorldPosition(this.position).removeNpc(this);
         clearInterval(this.randomMovementInterval);
@@ -158,6 +161,8 @@ export class Npc extends Actor {
     }
 
     public async tick(): Promise<void> {
+        super.tick();
+
         return new Promise<void>(resolve => {
             this.walkingQueue.process();
             resolve();

--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -130,7 +130,6 @@ export class Player extends Actor {
     private readonly _outgoingPackets: OutboundPacketHandler;
     private readonly _equipment: ItemContainer;
     private _rights: Rights;
-    private loggedIn: boolean;
     private _loginDate: Date;
     private _lastAddress: string;
     private firstTimePlayer: boolean;
@@ -172,7 +171,8 @@ export class Player extends Actor {
     }
 
     public async init(): Promise<void> {
-        this.loggedIn = true;
+        super.init();
+
         this.updateFlags.mapRegionUpdateRequired = true;
         this.updateFlags.appearanceUpdateRequired = true;
 
@@ -277,7 +277,7 @@ export class Player extends Actor {
     }
 
     public logout(): void {
-        if(!this.loggedIn) {
+        if(!this.active) {
             return;
         }
 
@@ -288,6 +288,8 @@ export class Player extends Actor {
         activeWorld.playerTree.remove(this.quadtreeKey);
         this.save();
 
+        this.destroy();
+
         this.actionsCancelled.complete();
         this.walkingQueue.movementEvent.complete();
         this.walkingQueue.movementQueued.complete();
@@ -297,7 +299,6 @@ export class Player extends Actor {
         activeWorld.chunkManager.getChunkForWorldPosition(this.position).removePlayer(this);
         activeWorld.deregisterPlayer(this);
 
-        this.loggedIn = false;
         logger.info(`${this.username} has logged out.`);
     }
 
@@ -371,6 +372,8 @@ export class Player extends Actor {
     }
 
     public async tick(): Promise<void> {
+        super.tick();
+
         return new Promise<void>(resolve => {
             this.walkingQueue.process();
 


### PR DESCRIPTION
This PR implements a tick-based task system for `Actors` (`Player`/`Npc`) and the `World`.

The main practical difference between this implementation and the previous `Behaviour` system is that the tasks here are synchronized for all entities in the world, and delays are handled by tick count rather than by milliseconds.

There are a number of configuration options for a `Task` as well as some useful subtasks. You can read more about these in the attached `README.md` file. The current set of subtasks is a starting point, and we will surely want to create more for more interaction types.

**If you'd like to see how content is written in this new task system, there are some PRs on my fork that you can view: https://github.com/Jameskmonger/runejs-server/pulls**

There are a number of `TODOs` around adding unit tests, I would like to propose that we keep these included for now - currently the areas are difficult to test due to complications with mocking the player class, but I have been working on other PRs to improve this.