### PR TITLE
Fixing a bug causing dialogue to crash and fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,8 +74,6 @@
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.4",
-                "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-                "chokidar": "^3.4.0",
                 "commander": "^4.0.1",
                 "convert-source-map": "^1.1.0",
                 "fs-readdir-recursive": "^1.1.0",
@@ -4046,7 +4044,6 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -6663,7 +6660,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.3.2",
                 "graceful-fs": "^4.2.9",
                 "jest-regex-util": "^29.4.3",
                 "jest-util": "^29.5.0",

--- a/src/engine/world/actor/dialogue.ts
+++ b/src/engine/world/actor/dialogue.ts
@@ -364,8 +364,6 @@ function parseDialogueTree(player: Player, npcParticipants: NpcParticipant[], di
                     }
                 }
 
-                console.log('npc:', npc);
-
                 dialogueDetails = dialogueAction(npc);
 
                 if (npc === -1) {

--- a/src/engine/world/actor/dialogue.ts
+++ b/src/engine/world/actor/dialogue.ts
@@ -364,14 +364,15 @@ function parseDialogueTree(player: Player, npcParticipants: NpcParticipant[], di
                     }
                 }
 
+                console.log('npc:', npc);
+
                 dialogueDetails = dialogueAction(npc);
+
+                if (npc === -1) {
+                    throw new Error('No npc found for dialogue action.');
+                }
             } else {
                 dialogueDetails = dialogueAction(player);
-            }
-
-            // TODO (Jameskmonger) not sure if this check is needed, added it when getting TypeScript types into strict mode
-            if (npc === -1) {
-                throw new Error('No npc found for dialogue action.');
             }
 
             const emote = dialogueDetails[0] as Emote;
@@ -582,10 +583,10 @@ async function runDialogueAction(player: Player, dialogueAction: string | Dialog
 
             if (dialogueAction.type === 'NPC') {
                 npcId = (dialogueAction as NpcDialogueAction).npcId;
-            }
-            // TODO (Jameskmonger) not sure if this check is needed, added it when getting TypeScript types into strict mode
-            if (npcId === -1) {
-                throw new Error('No npc found for dialogue action.');
+
+                if (npcId === -1) {
+                    throw new Error('No npc found for dialogue action.');
+                }
             }
 
             const actorDialogueAction = dialogueAction as ActorDialogueAction;


### PR DESCRIPTION
Currently on `develop`, attempting to talk to an NPC results in the following error and the dialogue tree does not initialize:

![image](https://github.com/runejs/server/assets/91903594/722f8a71-bd0c-4d76-b10b-e47804ef86de)

This PR fixes it. :)

![image](https://github.com/runejs/server/assets/91903594/37ba5e02-a201-4f45-9d6c-50fb04c681ba)
