### PR TITLE
refactor: migrate object_interaction walkTo hooks to use task system automatically

### DIFF
--- a/src/engine/action/pipe/item-on-object.action.ts
+++ b/src/engine/action/pipe/item-on-object.action.ts
@@ -4,6 +4,7 @@ import { Player } from '@engine/world/actor';
 import {
     ActionHook, getActionHooks, advancedNumberHookFilter, questHookFilter, ActionPipe, RunnableHooks
 } from '@engine/action';
+import { WalkToObjectPluginTask } from './task/walk-to-object-plugin-task';
 
 
 /**
@@ -81,6 +82,20 @@ const itemOnObjectActionPipe = (player: Player, landscapeObject: LandscapeObject
     if(matchingHooks.length === 0) {
         player.outgoingPackets.chatboxMessage(`Unhandled item on object interaction: ${ item.itemId } on ${ objectConfig.name } ` +
             `(id-${ landscapeObject.objectId }) @ ${ position.x },${ position.y },${ position.level }`);
+        return null;
+    }
+
+    const walkToPlugins = matchingHooks.filter(plugin => plugin.walkTo);
+
+    if (walkToPlugins.length > 0) {
+        player.enqueueBaseTask(new WalkToObjectPluginTask<ItemOnObjectAction>(walkToPlugins, player, landscapeObject, {
+            objectConfig,
+            item,
+            itemWidgetId,
+            itemContainerId,
+            cacheOriginal
+        }));
+
         return null;
     }
 

--- a/src/engine/action/pipe/object-interaction.action.ts
+++ b/src/engine/action/pipe/object-interaction.action.ts
@@ -4,6 +4,7 @@ import { Player } from '@engine/world/actor';
 import {
     ActionHook, getActionHooks, advancedNumberHookFilter, questHookFilter, ActionPipe, RunnableHooks
 } from '@engine/action';
+import { ActorLandscapeObjectInteractionTask } from '@engine/task/impl';
 
 
 /**
@@ -43,6 +44,84 @@ export interface ObjectInteractionAction {
     option: string;
 }
 
+/**
+ * This is a task to migrate old `walkTo` object interaction actions to the new task system.
+ *
+ * This is a first-pass implementation to allow for removal of the old action system.
+ * It will be refactored in future to be more well suited to our plugin system.
+ */
+class WalkToObjectInteractionTask extends ActorLandscapeObjectInteractionTask<Player> {
+    /**
+     * The plugins to execute when the player arrives at the object.
+     */
+    private plugins: ObjectInteractionActionHook[];
+
+    /**
+     * Additional details about the object that the action is being performed on.
+     */
+    private objectConfig: ObjectConfig; // TODO (jkm) move to base class
+
+    /**
+     * Whether or not this game object is an original map object or if it has been added/replaced.
+     */
+    private cacheOriginal: boolean;
+
+    /**
+     * The option that the player used (ie "cut" tree, or "smelt" furnace).
+     */
+    private option: string;
+
+    constructor(plugins: ObjectInteractionActionHook[], player: Player, landscapeObject: LandscapeObject, objectConfig: ObjectConfig, cacheOriginal: boolean, option: string) {
+        super(
+            player,
+            landscapeObject,
+            // TODO (jkm) handle object size
+            // TODO (jkm) pass orientation instead of size
+            1,
+            1,
+        );
+
+        this.plugins = plugins;
+        this.objectConfig = objectConfig;
+        this.cacheOriginal = cacheOriginal;
+        this.option = option;
+    }
+
+    /**
+     * Executed every tick to check if the player has arrived yet and calls the plugins if so.
+     */
+    public execute(): void {
+        // call super to manage waiting for the movement to complete
+        super.execute();
+
+        // check if the player has arrived yet
+        const landscapeObject = this.landscapeObject;
+        const landscapeObjectPosition = this.landscapeObjectPosition;
+        if (!landscapeObject || !landscapeObjectPosition) {
+            return;
+        }
+
+        // call the relevant plugins
+        this.plugins.forEach(plugin => {
+            if (!plugin || !plugin.handler) {
+                return;
+            }
+
+            plugin.handler({
+                player: this.actor,
+                object: landscapeObject,
+                objectConfig: this.objectConfig,
+                position: landscapeObjectPosition,
+                option: this.option,
+                cacheOriginal: this.cacheOriginal // TODO remove this - plugins shouldn't be concerned with whether objects are real or not
+            });
+        });
+
+        // this task only executes once, on arrival
+        this.stop();
+    }
+}
+
 
 /**
  * The pipe that the game engine hands object actions off to.
@@ -72,6 +151,14 @@ const objectInteractionActionPipe = (player: Player, landscapeObject: LandscapeO
     if(matchingHooks.length === 0) {
         player.outgoingPackets.chatboxMessage(`Unhandled object interaction: ${option} ${objectConfig.name} ` +
             `(id-${landscapeObject.objectId}) @ ${position.x},${position.y},${position.level}`);
+        return null;
+    }
+
+    const walkToPlugins = matchingHooks.filter(plugin => plugin.walkTo);
+
+    if (walkToPlugins.length > 0) {
+        player.enqueueBaseTask(new WalkToObjectInteractionTask(walkToPlugins, player, landscapeObject, objectConfig, cacheOriginal, option));
+
         return null;
     }
 

--- a/src/engine/action/pipe/object-interaction.action.ts
+++ b/src/engine/action/pipe/object-interaction.action.ts
@@ -4,7 +4,7 @@ import { Player } from '@engine/world/actor';
 import {
     ActionHook, getActionHooks, advancedNumberHookFilter, questHookFilter, ActionPipe, RunnableHooks
 } from '@engine/action';
-import { ActorLandscapeObjectInteractionTask } from '@engine/task/impl';
+import { WalkToObjectPluginTask } from './task/walk-to-object-plugin-task';
 
 
 /**
@@ -44,84 +44,6 @@ export interface ObjectInteractionAction {
     option: string;
 }
 
-/**
- * This is a task to migrate old `walkTo` object interaction actions to the new task system.
- *
- * This is a first-pass implementation to allow for removal of the old action system.
- * It will be refactored in future to be more well suited to our plugin system.
- */
-class WalkToObjectInteractionTask extends ActorLandscapeObjectInteractionTask<Player> {
-    /**
-     * The plugins to execute when the player arrives at the object.
-     */
-    private plugins: ObjectInteractionActionHook[];
-
-    /**
-     * Additional details about the object that the action is being performed on.
-     */
-    private objectConfig: ObjectConfig; // TODO (jkm) move to base class
-
-    /**
-     * Whether or not this game object is an original map object or if it has been added/replaced.
-     */
-    private cacheOriginal: boolean;
-
-    /**
-     * The option that the player used (ie "cut" tree, or "smelt" furnace).
-     */
-    private option: string;
-
-    constructor(plugins: ObjectInteractionActionHook[], player: Player, landscapeObject: LandscapeObject, objectConfig: ObjectConfig, cacheOriginal: boolean, option: string) {
-        super(
-            player,
-            landscapeObject,
-            // TODO (jkm) handle object size
-            // TODO (jkm) pass orientation instead of size
-            1,
-            1,
-        );
-
-        this.plugins = plugins;
-        this.objectConfig = objectConfig;
-        this.cacheOriginal = cacheOriginal;
-        this.option = option;
-    }
-
-    /**
-     * Executed every tick to check if the player has arrived yet and calls the plugins if so.
-     */
-    public execute(): void {
-        // call super to manage waiting for the movement to complete
-        super.execute();
-
-        // check if the player has arrived yet
-        const landscapeObject = this.landscapeObject;
-        const landscapeObjectPosition = this.landscapeObjectPosition;
-        if (!landscapeObject || !landscapeObjectPosition) {
-            return;
-        }
-
-        // call the relevant plugins
-        this.plugins.forEach(plugin => {
-            if (!plugin || !plugin.handler) {
-                return;
-            }
-
-            plugin.handler({
-                player: this.actor,
-                object: landscapeObject,
-                objectConfig: this.objectConfig,
-                position: landscapeObjectPosition,
-                option: this.option,
-                cacheOriginal: this.cacheOriginal // TODO remove this - plugins shouldn't be concerned with whether objects are real or not
-            });
-        });
-
-        // this task only executes once, on arrival
-        this.stop();
-    }
-}
-
 
 /**
  * The pipe that the game engine hands object actions off to.
@@ -157,7 +79,7 @@ const objectInteractionActionPipe = (player: Player, landscapeObject: LandscapeO
     const walkToPlugins = matchingHooks.filter(plugin => plugin.walkTo);
 
     if (walkToPlugins.length > 0) {
-        player.enqueueBaseTask(new WalkToObjectInteractionTask(walkToPlugins, player, landscapeObject, objectConfig, cacheOriginal, option));
+        player.enqueueBaseTask(new WalkToObjectPluginTask(walkToPlugins, player, landscapeObject, { objectConfig, cacheOriginal, option }));
 
         return null;
     }

--- a/src/engine/action/pipe/spawned-item-interaction.action.ts
+++ b/src/engine/action/pipe/spawned-item-interaction.action.ts
@@ -5,6 +5,7 @@ import {
     ActionHook, getActionHooks, numberHookFilter, stringHookFilter, questHookFilter, ActionPipe, RunnableHooks
 } from '@engine/action';
 import { logger } from '@runejs/common';
+import { WalkToItemPluginTask } from './task/walk-to-item-plugin-task';
 
 
 /**
@@ -36,6 +37,8 @@ export interface SpawnedItemInteractionAction {
     worldItem: WorldItem;
     // Details about the item
     itemDetails: ItemDetails;
+
+    // TODO (jkm) add "option" to the action
 }
 
 
@@ -80,6 +83,14 @@ const spawnedItemInteractionPipe = (player: Player, worldItem: WorldItem, option
 
     if(!itemDetails) {
         logger.error(`Item ${worldItem.itemId} not registered on the server [spawned-item-interaction action pipe]`);
+        return null;
+    }
+
+    const walkToPlugins = matchingHooks.filter(plugin => plugin.walkTo);
+
+    if (walkToPlugins.length > 0) {
+        player.enqueueBaseTask(new WalkToItemPluginTask(walkToPlugins, player, worldItem, itemDetails));
+
         return null;
     }
 

--- a/src/engine/action/pipe/task/walk-to-item-plugin-task.ts
+++ b/src/engine/action/pipe/task/walk-to-item-plugin-task.ts
@@ -1,0 +1,63 @@
+import { ItemDetails } from '@engine/config';
+import { ActorWorldItemInteractionTask } from '@engine/task/impl';
+import { WorldItem } from '@engine/world';
+import { Player } from '@engine/world/actor';
+import { SpawnedItemInteractionHook } from '../spawned-item-interaction.action';
+
+/**
+* This is a task to migrate old `walkTo` item interaction actions to the new task system.
+*
+* This is a first-pass implementation to allow for removal of the old action system.
+* It will be refactored in future to be more well suited to our plugin system.
+*/
+export class WalkToItemPluginTask extends ActorWorldItemInteractionTask<Player> {
+    /**
+     * The plugins to execute when the player arrives at the item.
+     */
+    private plugins: SpawnedItemInteractionHook[];
+
+    /**
+     * Details about the item
+     */
+    private itemDetails: ItemDetails;
+
+    constructor(plugins: SpawnedItemInteractionHook[], player: Player, worldItem: WorldItem, itemDetails: ItemDetails) {
+        super(
+            player,
+            worldItem
+        );
+
+        this.plugins = plugins;
+        this.itemDetails = itemDetails;
+    }
+
+    /**
+     * Executed every tick to check if the player has arrived yet and calls the plugins if so.
+     */
+    public execute(): void {
+        // call super to manage waiting for the movement to complete
+        super.execute();
+
+        // check if the player has arrived yet
+        const worldItem = this.worldItem;
+        if (!worldItem) {
+            return;
+        }
+
+        // call the relevant plugins
+        this.plugins.forEach(plugin => {
+            if (!plugin || !plugin.handler) {
+                return;
+            }
+
+            plugin.handler({
+                player: this.actor,
+                worldItem: worldItem,
+                itemDetails: this.itemDetails
+            });
+        });
+
+        // this task only executes once, on arrival
+        this.stop();
+    }
+}

--- a/src/engine/action/pipe/task/walk-to-object-plugin-task.ts
+++ b/src/engine/action/pipe/task/walk-to-object-plugin-task.ts
@@ -1,15 +1,23 @@
-import { LandscapeObject, ObjectConfig } from '@runejs/filestore';
-import { ActorLandscapeObjectInteractionTask, ActorWorldItemInteractionTask } from '@engine/task/impl';
-import { WorldItem } from '@engine/world';
+import { LandscapeObject } from '@runejs/filestore';
+import { ActorLandscapeObjectInteractionTask } from '@engine/task/impl';
 import { Player } from '@engine/world/actor';
-import { SpawnedItemInteractionHook } from '../spawned-item-interaction.action';
-import { ObjectInteractionAction, ObjectInteractionActionHook } from '../object-interaction.action';
-import { ItemOnObjectAction, ItemOnObjectActionHook } from '../item-on-object.action';
-import { ItemOnItemAction } from '../item-on-item.action';
+import { ObjectInteractionAction } from '../object-interaction.action';
+import { ItemOnObjectAction } from '../item-on-object.action';
 import { ActionHook } from '@engine/action/hook';
 
+/**
+ * All actions supported by this plugin task.
+ */
 type ObjectAction = ObjectInteractionAction | ItemOnObjectAction;
+
+/**
+ * An ActionHook for a supported ObjectAction.
+ */
 type ObjectActionHook<TAction extends ObjectAction> = ActionHook<TAction, (data: TAction) => void>;
+
+/**
+ * The data unique to the action being executed (i.e. excluding shared data)
+ */
 type ObjectActionData<TAction extends ObjectAction> = Omit<TAction, 'player' | 'object' | 'position'>;
 
 /**

--- a/src/engine/action/pipe/task/walk-to-object-plugin-task.ts
+++ b/src/engine/action/pipe/task/walk-to-object-plugin-task.ts
@@ -1,0 +1,76 @@
+import { LandscapeObject, ObjectConfig } from '@runejs/filestore';
+import { ActorLandscapeObjectInteractionTask, ActorWorldItemInteractionTask } from '@engine/task/impl';
+import { WorldItem } from '@engine/world';
+import { Player } from '@engine/world/actor';
+import { SpawnedItemInteractionHook } from '../spawned-item-interaction.action';
+import { ObjectInteractionAction, ObjectInteractionActionHook } from '../object-interaction.action';
+import { ItemOnObjectAction, ItemOnObjectActionHook } from '../item-on-object.action';
+import { ItemOnItemAction } from '../item-on-item.action';
+import { ActionHook } from '@engine/action/hook';
+
+type ObjectAction = ObjectInteractionAction | ItemOnObjectAction;
+type ObjectActionHook<TAction extends ObjectAction> = ActionHook<TAction, (data: TAction) => void>;
+type ObjectActionData<TAction extends ObjectAction> = Omit<TAction, 'player' | 'object' | 'position'>;
+
+/**
+* This is a task to migrate old `walkTo` item interaction actions to the new task system.
+*
+* This is a first-pass implementation to allow for removal of the old action system.
+* It will be refactored in future to be more well suited to our plugin system.
+*/
+export class WalkToObjectPluginTask<TAction extends ObjectAction> extends ActorLandscapeObjectInteractionTask<Player> {
+    /**
+     * The plugins to execute when the player arrives at the object.
+     */
+    private plugins: ObjectActionHook<TAction>[];
+
+    private data: ObjectActionData<TAction>;
+
+    constructor(plugins: ObjectActionHook<TAction>[], player: Player, landscapeObject: LandscapeObject, data: ObjectActionData<TAction>) {
+        super(
+            player,
+            landscapeObject,
+            // TODO (jkm) handle object size
+            // TODO (jkm) pass orientation instead of size
+            1,
+            1,
+        );
+
+        this.plugins = plugins;
+        this.data = data;
+    }
+
+    /**
+     * Executed every tick to check if the player has arrived yet and calls the plugins if so.
+     */
+    public execute(): void {
+        // call super to manage waiting for the movement to complete
+        super.execute();
+
+        // check if the player has arrived yet
+        const landscapeObject = this.landscapeObject;
+        const landscapeObjectPosition = this.landscapeObjectPosition;
+        if (!landscapeObject || !landscapeObjectPosition) {
+            return;
+        }
+
+        // call the relevant plugins
+        this.plugins.forEach(plugin => {
+            if (!plugin || !plugin.handler) {
+                return;
+            }
+
+            const action = {
+                player: this.actor,
+                object: landscapeObject,
+                position: landscapeObjectPosition,
+                ...this.data
+            } as TAction;
+
+            plugin.handler(action);
+        });
+
+        // this task only executes once, on arrival
+        this.stop();
+    }
+}

--- a/src/engine/task/impl/actor-landscape-object-interaction-task.ts
+++ b/src/engine/task/impl/actor-landscape-object-interaction-task.ts
@@ -60,12 +60,14 @@ export abstract class ActorLandscapeObjectInteractionTask<TActor extends Actor =
     constructor (
         actor: TActor,
         landscapeObject: LandscapeObject,
+        // TODO (jkm) get size/orientation automatically from the object's info
         sizeX: number = 1,
         sizeY: number = 1
     ) {
         super(
             actor,
             landscapeObject,
+            // TODO (jkm) atDestination must take orientation into account
             Math.max(sizeX, sizeY)
         );
 


### PR DESCRIPTION
More refactors needed in future to the ObjectInteractionTask / general Task system, but priority ATM is to migrate off the old system.