### PR TITLE
Enable all linting rules blocking unused code

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,10 @@
             },
             "correctness": {
                 "recommended": true,
-                "noSwitchDeclarations": "off"
+                "noUnusedFunctionParameters": "error",
+                "noUnusedImports": "error",
+                "noUnusedVariables": "error",
+                "noUnusedPrivateClassMembers": "error"
             },
             "performance": {
                 "recommended": true,
@@ -58,7 +61,6 @@
                 "noInferrableTypes": "off",
                 "noNonNullAssertion": "off",
                 "noParameterAssign": "off",
-                "noUnusedTemplateLiteral": "off",
                 "noUselessElse": "off",
                 "useEnumInitializers": "off",
                 "useImportType": "off",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "build:watch": "swc ./src -d dist -w --strip-leading-paths",
         "lint": "biome lint",
         "lint:fin": "biome lint --write --diagnostic-level=error --reporter=summary",
-        "lint:fix": "biome lint --write",
+        "lint:fix": "biome lint --write --unsafe",
         "format": "biome format",
         "format:fin": "biome format --write --reporter=summary",
         "format:fix": "biome format --write",

--- a/src/engine/action/hook/task.ts
+++ b/src/engine/action/hook/task.ts
@@ -112,7 +112,7 @@ export class TaskExecutor<T> {
             const response = await this.task.activate(this, this.iteration++);
             return typeof response === 'boolean' ? response : true;
         } catch (error) {
-            logger.error(`Error executing action task`);
+            logger.error('Error executing action task');
             logger.error(error);
             return false;
         }
@@ -130,7 +130,7 @@ export class TaskExecutor<T> {
         try {
             return this.task.canActivate(this, this.iteration);
         } catch (error) {
-            logger.error(`Error calling action canActivate`, this.task);
+            logger.error('Error calling action canActivate', this.task);
             logger.error(error);
             return false;
         }

--- a/src/engine/action/pipe/prayer.action.ts
+++ b/src/engine/action/pipe/prayer.action.ts
@@ -45,7 +45,7 @@ export interface PrayerAction {
  * @param buttonId
  */
 const prayerActionPipe = (npc: Npc, player: Player, widgetId: number, buttonId: number): RunnableHooks<PrayerAction> => {
-    console.info(`You used prayer`);
+    console.info('You used prayer');
 
     // Find all object action plugins that reference this location object
     const matchingHooks = getActionHooks<PrayerActionHook>('button');

--- a/src/engine/config/config-handler.ts
+++ b/src/engine/config/config-handler.ts
@@ -41,7 +41,7 @@ export async function loadCoreConfigurations(): Promise<void> {
 }
 
 export async function loadGameConfigurations(): Promise<void> {
-    logger.info(`Loading server configurations...`);
+    logger.info('Loading server configurations...');
 
     const { items, itemIds, itemPresets, itemGroups } = await loadItemConfigurations('data/config/items/');
     itemMap = items;

--- a/src/engine/config/data-dump.ts
+++ b/src/engine/config/data-dump.ts
@@ -23,7 +23,7 @@ function dump<T>(fileName: string, definitions: T[]): DataDumpResult {
             successful: true,
             filePath,
         };
-    } catch (error) {
+    } catch (_) {
         logger.error(`Error dumping ${fileName}`);
         return {
             successful: false,

--- a/src/engine/config/shop-config.test.ts
+++ b/src/engine/config/shop-config.test.ts
@@ -51,10 +51,9 @@ describe('shopping', () => {
 
     const shopname = 'rs:test_shop';
     let shop: Shop;
-    let world;
 
     beforeAll(async () => {
-        world = await setupConfig();
+        await setupConfig();
     });
 
     beforeEach(() => {

--- a/src/engine/net/inbound-packets/walk.packet.ts
+++ b/src/engine/net/inbound-packets/walk.packet.ts
@@ -16,6 +16,7 @@ const walkPacket = (player: Player, packet: PacketData) => {
     const totalSteps = Math.floor((size - 5) / 2);
 
     const firstY = buffer.get('short', 'u', 'le');
+    // biome-ignore lint/correctness/noUnusedVariables: Someone might need this one day I guess.
     const runSteps = buffer.get('byte') === 1; // @TODO forced running
     const firstX = buffer.get('short', 'u', 'le');
 

--- a/src/engine/net/outbound-packet-handler.ts
+++ b/src/engine/net/outbound-packet-handler.ts
@@ -57,7 +57,7 @@ export class OutboundPacketHandler {
         this.queue(packet);
     }
 
-    public sendPrivateMessage(chatId: number, sender: Player, message: number[]): void {
+    public sendPrivateMessage(sender: Player, message: number[]): void {
         const packet = new Packet(51, PacketType.DYNAMIC_SMALL);
         packet.put(stringToLong(sender.username.toLowerCase()), 'LONG');
         packet.put(32767, 'SHORT');
@@ -134,14 +134,7 @@ export class OutboundPacketHandler {
         this.queue(packet);
     }
 
-    public playSoundAtPosition(
-        soundId: number,
-        soundX: number,
-        soundY: number,
-        volume: number,
-        radius: number = 5,
-        delay: number = 0,
-    ): void {
+    public playSoundAtPosition(soundId: number, volume: number, radius: number = 5, delay: number = 0): void {
         const packet = new Packet(9);
         const offset = 0;
         packet.put(offset, 'BYTE');

--- a/src/engine/plugins/loader.ts
+++ b/src/engine/plugins/loader.ts
@@ -56,7 +56,7 @@ export async function loadPlugins(): Promise<void> {
                 }
             });
     } else {
-        logger.warn(`No action hooks detected - update plugins.`);
+        logger.warn('No action hooks detected - update plugins.');
     }
 
     for (const plugin of plugins) {

--- a/src/engine/task/impl/actor-walk-to-task.ts
+++ b/src/engine/task/impl/actor-walk-to-task.ts
@@ -22,7 +22,7 @@ type WalkToTarget = WalkToTargetType | (() => WalkToTargetType);
  *
  * @author jameskmonger
  */
-export interface ActorWalkToTask<TActor extends Actor = Actor, TTarget extends WalkToTarget = Position> extends ActorTask<TActor> {
+export interface ActorWalkToTask<TActor extends Actor = Actor> extends ActorTask<TActor> {
     /**
      * An optional function that is called when the actor arrives at the destination.
      */

--- a/src/engine/util/strings.ts
+++ b/src/engine/util/strings.ts
@@ -40,6 +40,7 @@ function getStylingType(tag: string) {
 }
 
 // Thank you to the Apollo team for these values. :)
+// biome-ignore lint/correctness/noUnusedVariables: Someone might want these one day!
 const charWidths = [
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 7, 14, 9, 12, 12, 4, 5, 5, 10, 8,
     4, 8, 4, 7, 9, 7, 9, 8, 8, 8, 9, 7, 9, 9, 4, 5, 7, 9, 7, 9, 14, 9, 8, 8, 8, 7, 7, 9, 8, 6, 8, 8, 7, 10, 9, 9, 8, 9, 8, 8, 6, 9, 8, 10,
@@ -71,7 +72,7 @@ export function wrapText(text: string, maxWidth: number, font?: number | string)
                 hidden = true;
                 currentTagIndex = currentLine.length + 1;
                 break;
-            case '>':
+            case '>': {
                 hidden = true;
                 const currentTag = currentLine.substring(currentTagIndex, currentLine.length);
                 currentTagIndex = -1;
@@ -91,6 +92,7 @@ export function wrapText(text: string, maxWidth: number, font?: number | string)
                     }
                 }
                 break;
+            }
             case '@':
                 break;
             case '\n':

--- a/src/engine/world/actor/actor.ts
+++ b/src/engine/world/actor/actor.ts
@@ -113,7 +113,7 @@ export abstract class Actor {
     public enqueueTask<T1>(taskClass: new (actor: Actor, arg1: T1) => Task, args: [T1]): void;
     public enqueueTask<T>(taskClass: new (actor: Actor, ...args: T[]) => Task, args: T[]): void {
         if (!this.active) {
-            logger.warn(`Attempted to instantiate task for inactive actor`);
+            logger.warn('Attempted to instantiate task for inactive actor');
             return;
         }
 
@@ -133,7 +133,7 @@ export abstract class Actor {
      */
     public enqueueBaseTask(task: Task): void {
         if (!this.active) {
-            logger.warn(`Attempted to enqueue task for  inactive actor`);
+            logger.warn('Attempted to enqueue task for  inactive actor');
             return;
         }
 
@@ -437,7 +437,7 @@ export abstract class Actor {
 
             let valid = true;
 
-            if (!this.withinBounds(px, py)) {
+            if (isNpc(this) && !this.withinBounds(px, py)) {
                 valid = false;
             }
 
@@ -473,7 +473,7 @@ export abstract class Actor {
                 px += movementDirection.deltaX;
                 py += movementDirection.deltaY;
 
-                if (!this.withinBounds(px, py)) {
+                if (isNpc(this) && !this.withinBounds(px, py)) {
                     valid = false;
                 }
             }
@@ -486,10 +486,6 @@ export abstract class Actor {
             this.walkingQueue.valid = true;
             this.walkingQueue.add(px, py);
         }
-    }
-
-    public withinBounds(x: number, y: number): boolean {
-        return true;
     }
 
     /**

--- a/src/engine/world/actor/dialogue.ts
+++ b/src/engine/world/actor/dialogue.ts
@@ -297,8 +297,8 @@ function parseDialogueTree(player: Player, npcParticipants: NpcParticipant[], di
             }
 
             if (isOptions) {
-                const options = (result as any[]).filter((option, index) => index % 2 === 0);
-                const trees = (result as any[]).filter((option, index) => index % 2 !== 0);
+                const options = (result as any[]).filter((_, index) => index % 2 === 0);
+                const trees = (result as any[]).filter((_, index) => index % 2 !== 0);
                 const optionsDialogueAction: OptionsDialogueAction = {
                     options: {},
                     tag: tag || '',
@@ -784,7 +784,7 @@ export async function itemSelectionDialogue(player: Player, type: 'COOKING' | 'M
             widgetId = 309;
         } else {
             if (items.length > 5) {
-                throw new Error(`Too many items provided to the item selection action!`);
+                throw new Error('Too many items provided to the item selection action!');
             }
 
             widgetId = 301 + items.length;

--- a/src/engine/world/actor/npc.ts
+++ b/src/engine/world/actor/npc.ts
@@ -125,7 +125,7 @@ export class Npc extends Actor {
 
     //This is useful so that we can tie into things like "spell casts" or events, or traps, etc to finish quests or whatever
     public async processDeath(assailant: Actor, defender: Actor): Promise<void> {
-        return new Promise<void>(resolve => {
+        return new Promise<void>(() => {
             const deathPosition = defender.position;
 
             let deathAnim: number = animationIds.death;

--- a/src/engine/world/actor/pathfinding.ts
+++ b/src/engine/world/actor/pathfinding.ts
@@ -127,7 +127,7 @@ export class Pathfinding {
         const highestY = position.y + searchRadius;
 
         if (destinationX < lowestX || destinationX > highestX || destinationY < lowestY || destinationY > highestY) {
-            throw new Error(`Out of range.`);
+            throw new Error('Out of range.');
         }
 
         const destinationIndexX = destinationX - position.x + searchRadius;
@@ -138,10 +138,10 @@ export class Pathfinding {
         const pointLen = searchRadius * 2;
 
         if (pointLen <= 0) {
-            throw new Error(`Why is your search radius zero?`);
+            throw new Error('Why is your search radius zero?');
         }
 
-        this.points = [...Array(pointLen)].map(e => Array(pointLen));
+        this.points = [...Array(pointLen)].map(() => Array(pointLen));
 
         for (let x = 0; x < pointLen; x++) {
             for (let y = 0; y < pointLen; y++) {
@@ -250,7 +250,7 @@ export class Pathfinding {
             iterations++;
 
             if (iterations > 1000) {
-                throw new Error(`Path iteration overflow, path can not be found.`);
+                throw new Error('Path iteration overflow, path can not be found.');
             }
 
             if (point === null) {
@@ -414,7 +414,7 @@ export class Pathfinding {
             const globalTileFlags = globalAdjacencyForTile === null ? null : globalAdjacencyForTile & i;
 
             return instancedTileFlags === null ? globalTileFlags === 0 : instancedTileFlags === 0;
-        } catch (error) {
+        } catch (_) {
             logger.error(`Unable to calculate movement permission for local coordinates ${destinationLocalX},${destinationLocalY}.`);
             return false;
         }

--- a/src/engine/world/actor/player/achievements.ts
+++ b/src/engine/world/actor/player/achievements.ts
@@ -36,7 +36,7 @@ export const Achievements: { [key: string]: Achievement } = {
         id: 'bury-bones',
         name: 'Grave Digger',
         description: 'Bury the bones of the dead.',
-        longDescription: `Bury the remains of a deceased enemy.`,
+        longDescription: 'Bury the remains of a deceased enemy.',
         series: AchievementSeries.LUMBRIDGE,
     },
 };

--- a/src/engine/world/actor/player/dialogue-action.ts
+++ b/src/engine/world/actor/player/dialogue-action.ts
@@ -146,7 +146,7 @@ export class DialogueAction {
             this.p.outgoingPackets.updateWidgetString(widgetId, textOffset + i, options.lines[i]);
         }
 
-        return new Promise<DialogueAction>((resolve, reject) => {
+        return new Promise<DialogueAction>(resolve => {
             this.p.interfaceState.openWidget(widgetId, {
                 slot: 'chatbox',
             });

--- a/src/engine/world/actor/player/player-data.ts
+++ b/src/engine/world/actor/player/player-data.ts
@@ -145,7 +145,7 @@ export function savePlayerData(player: Player): boolean {
     try {
         writeFileSync(filePath, JSON.stringify(playerSave, null, 4));
         return true;
-    } catch (error) {
+    } catch (_) {
         logger.error(`Error saving player data for ${player.username}.`);
         return false;
     }
@@ -177,7 +177,7 @@ export function loadPlayerSave(username: string): PlayerSave | null {
             playerSave.position.level = 0;
         }
         return playerSave;
-    } catch (error) {
+    } catch (_) {
         logger.error(`Malformed player save data for ${username}.`);
         return null;
     }

--- a/src/engine/world/actor/player/player.ts
+++ b/src/engine/world/actor/player/player.ts
@@ -238,14 +238,14 @@ export class Player extends Actor {
             this.outgoingPackets.updateWidgetString(
                 widgets.welcomeScreenChildren.question,
                 1,
-                `Want to help RuneJS improve?\\nSend us a pull request over on Github!`,
+                'Want to help RuneJS improve?\\nSend us a pull request over on Github!',
             );
             this.outgoingPackets.updateWidgetString(
                 widgets.welcomeScreen,
                 13,
                 `You last logged in @red@${loginDaysStr}@bla@ from: @red@${this.lastAddress}`,
             );
-            this.outgoingPackets.updateWidgetString(widgets.welcomeScreen, 16, `You have @yel@0 unread messages\\nin your message centre.`);
+            this.outgoingPackets.updateWidgetString(widgets.welcomeScreen, 16, 'You have @yel@0 unread messages\\nin your message centre.');
             this.outgoingPackets.updateWidgetString(
                 widgets.welcomeScreen,
                 14,
@@ -259,7 +259,7 @@ export class Player extends Actor {
             this.outgoingPackets.updateWidgetString(
                 widgets.welcomeScreen,
                 17,
-                `\\nYou do not have a Bank PIN.\\nPlease visit a bank if you would like one.`,
+                '\\nYou do not have a Bank PIN.\\nPlease visit a bank if you would like one.',
             );
             this.outgoingPackets.updateWidgetString(
                 widgets.welcomeScreen,
@@ -365,7 +365,7 @@ export class Player extends Actor {
     }
 
     public privateMessageReceived(fromPlayer: Player, messageBytes: number[]): void {
-        this.outgoingPackets.sendPrivateMessage(this.privateMessageIndex++, fromPlayer, messageBytes);
+        this.outgoingPackets.sendPrivateMessage(fromPlayer, messageBytes);
     }
 
     public addFriend(friendName: string): boolean {
@@ -417,9 +417,6 @@ export class Player extends Actor {
         // @TODO emit event to friend service watcher
         this.ignoreList.splice(index, 1);
         return true;
-    }
-    public onNpcKill(npc: Npc) {
-        console.log('killed npc');
     }
     /**
      * Should be fired whenever the player's chunk changes. This will fire off chunk updates for all chunks not
@@ -711,7 +708,7 @@ export class Player extends Actor {
                 messages[i] = messages[i]?.trim() || '';
             }
 
-            return await dialogue([this], [text => (messages as string[]).join(' ')]);
+            return await dialogue([this], [() => (messages as string[]).join(' ')]);
         }
 
         if (showInConsole) {
@@ -1122,7 +1119,7 @@ export class Player extends Actor {
         }
 
         if (!npc) {
-            logger.error(`NPC not found.`);
+            logger.error('NPC not found.');
             return;
         }
 
@@ -1166,7 +1163,7 @@ export class Player extends Actor {
             if (event.slot !== undefined && event.item !== undefined) {
                 this.outgoingPackets.sendUpdateSingleWidgetItem(widgets.inventory, event.slot, event.item);
             } else {
-                logger.error(`Inventory update event was missing slot or item.`, event);
+                logger.error('Inventory update event was missing slot or item.', event);
             }
         }
         this.updateCarryWeight();

--- a/src/engine/world/actor/player/private-messaging.ts
+++ b/src/engine/world/actor/player/private-messaging.ts
@@ -8,11 +8,6 @@ export enum PrivateChatMode {
 }
 
 export class PrivateMessaging {
-    public static friendAdded(player: Player, friendName: string): void {
-        friendName = friendName.toLowerCase();
-        const friend = activeWorld?.findPlayer(friendName);
-    }
-
     public static friendRemoved(player: Player, friendName: string): void {
         friendName = friendName.toLowerCase();
         const playerPrivateChatMode = player.settings.privateChatMode;

--- a/src/engine/world/actor/player/sync/actor-sync.ts
+++ b/src/engine/world/actor/player/sync/actor-sync.ts
@@ -13,7 +13,6 @@ import type { Player } from '../player';
  * Handles the registration of nearby NPCs or Players for the specified player.
  */
 export function registerNewActors(
-    packet: Packet,
     player: Player,
     trackedActors: Actor[],
     nearbyActors: QuadtreeKey[],

--- a/src/engine/world/actor/player/sync/npc-sync-task.ts
+++ b/src/engine/world/actor/player/sync/npc-sync-task.ts
@@ -45,7 +45,7 @@ export class NpcSyncTask extends SyncTask<void> {
                 nearbyNpcs,
             ) as Npc[];
 
-            registerNewActors(npcUpdatePacket, this.player, this.player.trackedNpcs, nearbyNpcs, actor => {
+            registerNewActors(this.player, this.player.trackedNpcs, nearbyNpcs, actor => {
                 const newNpc = actor as Npc;
                 const positionOffsetX = newNpc.position.x - this.player.position.x;
                 const positionOffsetY = newNpc.position.y - this.player.position.y;

--- a/src/engine/world/actor/player/sync/player-sync-task.ts
+++ b/src/engine/world/actor/player/sync/player-sync-task.ts
@@ -69,7 +69,7 @@ export class PlayerSyncTask extends SyncTask<void> {
                 nearbyPlayers,
             ) as Player[];
 
-            registerNewActors(playerUpdatePacket, this.player, this.player.trackedPlayers, nearbyPlayers, actor => {
+            registerNewActors(this.player, this.player.trackedPlayers, nearbyPlayers, actor => {
                 const newPlayer = actor as Player;
                 const positionOffsetX = newPlayer.position.x - this.player.position.x;
                 const positionOffsetY = newPlayer.position.y - this.player.position.y;

--- a/src/engine/world/actor/skills.ts
+++ b/src/engine/world/actor/skills.ts
@@ -272,7 +272,7 @@ export class Skills extends SkillShortcuts {
                         this.actor,
                         () => {
                             (this.actor as Player).sendMessage(
-                                `Congratulations, you just advanced a ` + `${achievementDetails.name.toLowerCase()} level.`,
+                                `Congratulations, you just advanced a ${achievementDetails.name.toLowerCase()} level.`,
                             );
                             this.showLevelUpDialogue(skill, finalLevel);
                             return {

--- a/src/engine/world/config/harvestable-object.ts
+++ b/src/engine/world/config/harvestable-object.ts
@@ -428,7 +428,7 @@ export function getTreeFromHealthy(id: number): IHarvestable {
 
 export function getOreFromDepletedRock(id: number): IHarvestable {
     return Ores.find(ore => {
-        for (const [rock, expired] of ore.objects) {
+        for (const [_, expired] of ore.objects) {
             if (expired === id) {
                 return true;
             }
@@ -451,7 +451,7 @@ export function getAllOreIds(): number[] {
 export function getTreeIds(): number[] {
     const treeIds: number[] = [];
     for (const tree of Trees) {
-        for (const [healthy, expired] of tree.objects) {
+        for (const [healthy] of tree.objects) {
             treeIds.push(healthy);
         }
     }

--- a/src/engine/world/instances.ts
+++ b/src/engine/world/instances.ts
@@ -259,10 +259,9 @@ export class WorldInstance {
     /**
      * Spawns a temporary game object within the game world.
      * @param object The game object to spawn.
-     * @param position The position to spawn the object at.
      * @param despawnTicks The number of game cycles/ticks before the object will de-spawn.
      */
-    public async spawnTemporaryGameObject(object: LandscapeObject, position: Position, despawnTicks: number): Promise<void> {
+    public async spawnTemporaryGameObject(object: LandscapeObject, despawnTicks: number): Promise<void> {
         this.spawnGameObject(object);
         await schedule(despawnTicks);
         this.despawnGameObject(object);
@@ -321,10 +320,9 @@ export class WorldInstance {
     /**
      * Spawn a new game object into the instance.
      * @param object The game object to spawn.
-     * @param reference Whether or not the object being spawned is a reference to an existing object or if it should
      * be sent to the game client for forced rendering. Defaults to false for forced rendering.
      */
-    public spawnGameObject(object: LandscapeObject, reference: boolean = false): void {
+    public spawnGameObject(object: LandscapeObject): void {
         const position = new Position(object.x, object.y, object.level);
 
         const { chunk: instancedChunk, mods } = this.getTileModifications(position);

--- a/src/engine/world/items/item-container.ts
+++ b/src/engine/world/items/item-container.ts
@@ -48,7 +48,7 @@ export class ItemContainer {
     }
 
     public clear(fireEvent: boolean = true): void {
-        this._items.forEach((item, index) => (this._items[index] = null));
+        this._items.forEach((_, index) => (this._items[index] = null));
 
         if (fireEvent) {
             this._containerUpdated.next({ type: 'CLEAR_ALL' });

--- a/src/engine/world/map/chunk-manager.ts
+++ b/src/engine/world/map/chunk-manager.ts
@@ -91,12 +91,12 @@ export class ChunkManager {
 
         try {
             mapFile = filestore.regionStore.getMapFile(mapRegionX, mapRegionY);
-        } catch (error) {
+        } catch (_) {
             logger.error(`Error decoding map file ${mapRegionX},${mapRegionY}`);
         }
         try {
             landscapeFile = filestore.regionStore.getLandscapeFile(mapRegionX, mapRegionY);
-        } catch (error) {
+        } catch (_) {
             logger.error(`Error decoding landscape file ${mapRegionX},${mapRegionY}`);
         }
 

--- a/src/engine/world/world.ts
+++ b/src/engine/world/world.ts
@@ -80,7 +80,7 @@ export class World {
 
     public shutdown(): void {
         this.kickAllPlayers();
-        logger.info(`Shutting down world...`);
+        logger.info('Shutting down world...');
     }
 
     /**
@@ -267,11 +267,11 @@ export class World {
             return;
         }
 
-        logger.info(`Kicking all players...`);
+        logger.info('Kicking all players...');
 
         this.playerList.filter(player => player !== null).forEach(player => player.logout());
 
-        logger.info(`Player data save complete, world is now empty.`);
+        logger.info('Player data save complete, world is now empty.');
     }
 
     /**
@@ -282,11 +282,11 @@ export class World {
             return;
         }
 
-        logger.info(`Saving player data...`);
+        logger.info('Saving player data...');
 
         this.playerList.filter(player => player !== null).forEach(player => player.save());
 
-        logger.info(`Player data saved.`);
+        logger.info('Player data saved.');
     }
 
     /**
@@ -299,7 +299,7 @@ export class World {
     public playLocationSound(position: Position, instanceId: string, soundId: number, volume: number, distance: number = 10): void {
         this.findNearbyPlayers(position, distance, instanceId).forEach(player => {
             player.outgoingPackets.updateReferencePosition(position);
-            player.outgoingPackets.playSoundAtPosition(soundId, position.x, position.y, volume);
+            player.outgoingPackets.playSoundAtPosition(soundId, volume);
         });
     }
 
@@ -427,13 +427,7 @@ export class World {
         });
     }
 
-    public async spawnNpc(
-        npcKey: string | number,
-        position: Position,
-        face: Direction,
-        movementRadius: number = 0,
-        instanceId: string = activeWorld.globalInstance.instanceId,
-    ): Promise<Npc> {
+    public async spawnNpc(npcKey: string | number, position: Position, face: Direction, movementRadius: number = 0): Promise<Npc> {
         if (!npcKey) {
             throw new Error('NPC key must be provided.');
         }

--- a/src/plugins/buttons/magic-attack.plugin.ts
+++ b/src/plugins/buttons/magic-attack.plugin.ts
@@ -1,20 +1,13 @@
 import type { TaskExecutor } from '@engine/action/hook/task';
 import type { MagicOnNPCAction, MagicOnNPCActionHook } from '@engine/action/pipe/magic-on-npc.action';
-import type { Player } from '@engine/world/actor/player/player';
-import { logger } from '@runejs/common';
 
 const buttonIds: number[] = [
     0, // Home Teleport
 ];
 
-function attack_target(player: Player, elapsedTicks: number): boolean {
-    logger.info('attacking?');
-    return true;
-}
-
 const spells = ['Wind Strike', 'Confuse', 'Water Strike', 'unknown?', 'Earth Strike'];
-export const activate = (task: TaskExecutor<MagicOnNPCAction>, elapsedTicks: number = 0) => {
-    const { npc, player, widgetId, buttonId } = task.actionData;
+export const activate = (task: TaskExecutor<MagicOnNPCAction>) => {
+    const { npc, player, buttonId } = task.actionData;
 
     const attackerX = player.position.x;
     const attackerY = player.position.y;

--- a/src/plugins/buttons/player-emotes.plugin.ts
+++ b/src/plugins/buttons/player-emotes.plugin.ts
@@ -167,14 +167,14 @@ export const handler: buttonActionHandler = details => {
                 }
             }
         } else {
-            player.sendMessage(`You need to be wearing a skillcape in order to perform that emote.`, true);
+            player.sendMessage('You need to be wearing a skillcape in order to perform that emote.', true);
         }
     } else {
         if (emote.unlockable) {
             const unlockedEmotes: string[] = player.savedMetadata.unlockedEmotes || [];
 
             if (unlockedEmotes.indexOf(emote.name) === -1) {
-                player.sendMessage(`You have not unlocked this emote.`, true);
+                player.sendMessage('You have not unlocked this emote.', true);
                 return;
             }
         }

--- a/src/plugins/commands/data-dump-command.plugin.ts
+++ b/src/plugins/commands/data-dump-command.plugin.ts
@@ -15,7 +15,7 @@ const action: commandActionHandler = ({ player, args, isConsole }) => {
     const types = Object.keys(functionMap);
 
     if (types.indexOf(dataType) === -1) {
-        player.sendLogMessage(`Invalid data type, please use one of the following:`, isConsole);
+        player.sendLogMessage('Invalid data type, please use one of the following:', isConsole);
         player.sendLogMessage(`[ ${types.join(', ')} ]`, isConsole);
         return;
     }

--- a/src/plugins/commands/give-item-command.plugin.ts
+++ b/src/plugins/commands/give-item-command.plugin.ts
@@ -27,13 +27,13 @@ const action: commandActionHandler = details => {
     }
 
     if (!itemId || isNaN(itemId)) {
-        throw new Error(`Item name not found.`);
+        throw new Error('Item name not found.');
     }
 
     let amount: number = args.amount as number;
 
     if (amount > 2000000000) {
-        throw new Error(`Unable to give more than 2,000,000,000.`);
+        throw new Error('Unable to give more than 2,000,000,000.');
     }
 
     const itemDefinition = findItem(itemId);

--- a/src/plugins/commands/region-debug-commands.plugin.ts
+++ b/src/plugins/commands/region-debug-commands.plugin.ts
@@ -16,7 +16,7 @@ const debugMapRegion = (
     player.sendMessage(`Region ${key} - ${activeWorld.chunkManager.getRegionIdForWorldPosition(player.position)}`);
 
     if (!activeWorld.chunkManager.regionMap.has(key)) {
-        player.sendMessage(`Map region not loaded.`);
+        player.sendMessage('Map region not loaded.');
         return;
     }
 
@@ -27,7 +27,7 @@ const debugMapRegion = (
     const region = activeWorld.chunkManager.regionMap.get(key);
 
     if (!region) {
-        player.sendMessage(`Map region not loaded.`);
+        player.sendMessage('Map region not loaded.');
         logger.error(`Map region not loaded. ${key}`);
         return;
     }

--- a/src/plugins/commands/spawn-scenery-command.plugin.ts
+++ b/src/plugins/commands/spawn-scenery-command.plugin.ts
@@ -17,7 +17,7 @@ const spawnSceneryAction: commandActionHandler = ({ player, args }) => {
     }
 
     if (isNaN(locationObjectId)) {
-        throw new Error(`Location object name not found.`);
+        throw new Error('Location object name not found.');
     }
 
     const objectType = args.objectType as number;

--- a/src/plugins/commands/spawn-test-players-command.plugin.ts
+++ b/src/plugins/commands/spawn-test-players-command.plugin.ts
@@ -21,7 +21,7 @@ const handler: commandActionHandler = ({ player, args }) => {
 
     const worldSlotsRemaining = activeWorld.playerSlotsRemaining() - 1;
     if (worldSlotsRemaining <= 0) {
-        player.sendMessage(`Error: The game world is full.`);
+        player.sendMessage('Error: The game world is full.');
         return;
     }
 

--- a/src/plugins/commands/stat-commands.plugin.ts
+++ b/src/plugins/commands/stat-commands.plugin.ts
@@ -5,7 +5,7 @@ const setLevelAction: commandActionHandler = ({ player, args }) => {
     const level: number | null = (args?.level as number) || null;
 
     if (!skillId || !level) {
-        player.sendMessage(`Invalid syntax: Use ::setlevel skill_id skill_level`);
+        player.sendMessage('Invalid syntax: Use ::setlevel skill_id skill_level');
         return;
     }
 

--- a/src/plugins/commands/transform-command.plugin.ts
+++ b/src/plugins/commands/transform-command.plugin.ts
@@ -3,7 +3,7 @@ import type { PlayerCommandActionHook, commandActionHandler } from '@engine/acti
 const action: commandActionHandler = details => {
     const { player, args } = details;
 
-    player.transformInto(details && details.args ? details.args['npcKey'] : null);
+    player.transformInto(details && args ? args['npcKey'] : null);
 };
 
 export default {

--- a/src/plugins/items/drop-item.plugin.ts
+++ b/src/plugins/items/drop-item.plugin.ts
@@ -20,16 +20,16 @@ export const handler: itemInteractionActionHandler = ({ player, itemId, itemSlot
         dialogue(
             [player],
             [
-                text => 'Administrators are not allowed to drop items.',
-                options => [
-                    `Destroy the item!`,
+                _text => 'Administrators are not allowed to drop items.',
+                _options => [
+                    'Destroy the item!',
                     [
                         execute(() => {
                             inventory.remove(itemSlot);
                             player.outgoingPackets.sendUpdateSingleWidgetItem(widgets.inventory, itemSlot, null);
                         }),
                     ],
-                    `Bank the item!`,
+                    'Bank the item!',
                     [
                         execute(() => {
                             inventory.remove(itemSlot);

--- a/src/plugins/items/rotten-potato/helpers/rotten-potato-travel.ts
+++ b/src/plugins/items/rotten-potato/helpers/rotten-potato-travel.ts
@@ -21,18 +21,16 @@ export function openTravel(player: Player, page: number) {
         hidden: widget.metadata.page === 1, // hide prev page button if we are on the first page
     });
 
-    const isLastPage = p => pageCount === page * 2; // 2 "pages" per page
-
     // Next page buttton
     player.modifyWidget(widget.widgetId, {
         childId: 97,
-        hidden: isLastPage(page),
+        hidden: pageCount === page * 2, // 2 "pages" per page
     });
 
     // prev page label
     player.modifyWidget(widget.widgetId, {
         childId: 98,
-        text: widget.metadata.page * 2 - 1 === 1 ? `` : `Page ${widget.metadata.page * 2 - 1} `,
+        text: widget.metadata.page * 2 - 1 === 1 ? '' : `Page ${widget.metadata.page * 2 - 1} `,
     });
 
     // next page label

--- a/src/plugins/items/rotten-potato/hooks/rotten-potato-eat.ts
+++ b/src/plugins/items/rotten-potato/hooks/rotten-potato-eat.ts
@@ -15,16 +15,16 @@ const eatPotato: itemInteractionActionHandler = async details => {
     await dialogue(
         [details.player],
         [
-            options => [
-                `Set all stats`,
+            () => [
+                'Set all stats',
                 [execute(() => (chosenOption = DialogueOption.SET_ALL_STATS))],
-                `Wipe inventory`,
+                'Wipe inventory',
                 [execute(() => (chosenOption = DialogueOption.WIPE_INVENTORY))],
-                `Setup POH`,
+                'Setup POH',
                 [execute(() => (chosenOption = DialogueOption.SETUP_POH))],
-                `Teleport to player`,
+                'Teleport to player',
                 [execute(() => (chosenOption = DialogueOption.TELEPORT_TO_PLAYER))],
-                `Spawn aggressive NPC`,
+                'Spawn aggressive NPC',
                 [execute(() => (chosenOption = DialogueOption.SPAWN_AGGRESSIVE_NPC))],
             ],
         ],

--- a/src/plugins/items/rotten-potato/hooks/rotten-potato-peel.ts
+++ b/src/plugins/items/rotten-potato/hooks/rotten-potato-peel.ts
@@ -47,10 +47,10 @@ const peelPotato: itemInteractionActionHandler = async details => {
     await dialogue(
         [details.player],
         [
-            options => [
-                `Bank menu`,
+            () => [
+                'Bank menu',
                 [execute(() => (chosenOption = DialogueOption.BANK))],
-                `Travel Far!`,
+                'Travel Far!',
                 [execute(() => (chosenOption = DialogueOption.TELEPORT_MENU))],
                 // `Teleport to RARE!`, [
                 //     execute(() => chosenOption = DialogueOption.TELEPORT_TO_RARE_DROP)

--- a/src/plugins/items/shopping/buy-from-shop.plugin.ts
+++ b/src/plugins/items/shopping/buy-from-shop.plugin.ts
@@ -76,7 +76,7 @@ export const handler: itemInteractionActionHandler = details => {
     const inventory = player.inventory;
 
     if (buyItem.stackable) {
-        const inventoryStackSlot = inventory.items.findIndex(item => itemId === itemId);
+        const inventoryStackSlot = inventory.items.findIndex(item => item?.itemId === itemId);
 
         if (inventoryStackSlot === -1) {
             if (inventory.getFirstOpenSlot() === -1) {

--- a/src/plugins/items/shopping/item-value.plugin.ts
+++ b/src/plugins/items/shopping/item-value.plugin.ts
@@ -3,7 +3,7 @@ import { findItem, findShop, widgets } from '@engine/config/config-handler';
 import { getItemFromContainer } from '@engine/world/items/item-container';
 
 export const shopSellValueHandler: itemInteractionActionHandler = details => {
-    const { player, itemId, itemSlot, widgetId, option } = details;
+    const { player, itemId, itemSlot, widgetId } = details;
 
     if (!player.interfaceState.findWidget(widgetId)) {
         return;
@@ -25,12 +25,12 @@ export const shopSellValueHandler: itemInteractionActionHandler = details => {
 
     if (!shopItem) {
         // The specified item was not found in the specified slot.
-        player.sendMessage(`ERROR item not in shopslot.`);
+        player.sendMessage('ERROR item not in shopslot.');
         return;
     }
 
     if (shopItem.amount <= 0) {
-        player.sendMessage(`The shop has ran out of stock.`);
+        player.sendMessage('The shop has ran out of stock.');
         // Out of stock
         return;
     }

--- a/src/plugins/music/music-regions.plugin.ts
+++ b/src/plugins/music/music-regions.plugin.ts
@@ -5,12 +5,6 @@ import { MusicPlayerMode } from '@engine/world/sound/music';
 
 musicRegions.forEach(song => song.regionIds.forEach(region => musicRegionMap.set(region, song.songId)));
 
-function getByValue(map, searchValue) {
-    for (const [key, value] of map.entries()) {
-        if (value === searchValue) return key;
-    }
-}
-
 const regionChangedHandler = ({ player, currentMapRegionId }): void => {
     const songId = findSongIdByRegionId(currentMapRegionId);
     if (songId == null) {
@@ -24,7 +18,6 @@ const regionChangedHandler = ({ player, currentMapRegionId }): void => {
     }
 
     const songName = musicTrack.songName;
-    // player.sendMessage(`Playing ${songId}:${getByValue(songs, songId)} at region ${currentMapRegionId}`);
     if (!player.musicTracks.includes(songId)) {
         player.musicTracks.push(songId);
         player.sendMessage('You have unlocked a new music track: <col=ef101f>' + songName + '.</col>');

--- a/src/plugins/music/music-tab.plugin.ts
+++ b/src/plugins/music/music-tab.plugin.ts
@@ -13,7 +13,7 @@ export const handler: buttonActionHandler = details => {
         const songIdForCurrentRegion = findSongIdByRegionId(activeWorld.chunkManager.getRegionIdForWorldPosition(player.position));
 
         if (!songIdForCurrentRegion) {
-            logger.warn(`No song found for current region`);
+            logger.warn('No song found for current region');
             return;
         }
 

--- a/src/plugins/npcs/al-kharid/karim.plugin.ts
+++ b/src/plugins/npcs/al-kharid/karim.plugin.ts
@@ -10,13 +10,13 @@ const talkToAction: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'karim' }],
         [
-            karim => [Emote.HAPPY, `Would you like to buy a nice kebab? Only one gold.`],
-            options => [
+            _karim => [Emote.HAPPY, 'Would you like to buy a nice kebab? Only one gold.'],
+            _options => [
                 `I think i'll give it a miss.`,
-                [player => [Emote.DROWZY, `I think i'll give it a miss.`]],
-                `Yes please.`,
+                [_player => [Emote.DROWZY, `I think i'll give it a miss.`]],
+                'Yes please.',
                 [
-                    player => [Emote.HAPPY, `Yes please.`],
+                    _player => [Emote.HAPPY, 'Yes please.'],
                     execute(() => {
                         const inventory = player.inventory;
                         if (inventory.has(itemIds.coins)) {
@@ -47,8 +47,8 @@ const talkToAction: npcInteractionActionHandler = details => {
                             dialogue(
                                 [player, { npc, key: 'karim' }],
                                 [
-                                    player => [Emote.ANGRY, `Oops, I forgot to bring any money with me.`],
-                                    karim => [Emote.GENERIC, `Come back when you have some.`],
+                                    _player => [Emote.ANGRY, 'Oops, I forgot to bring any money with me.'],
+                                    _karim => [Emote.GENERIC, 'Come back when you have some.'],
                                 ],
                             );
                         }

--- a/src/plugins/npcs/falador/custom-guards.plugin.ts
+++ b/src/plugins/npcs/falador/custom-guards.plugin.ts
@@ -53,7 +53,7 @@ const dialogueTrees: DialogueNpcTree[][] = [
             b: `Well... It's kind of weird to be saying this, given the nature of my work,`,
         },
         {
-            b: `but I really think you should think twice about this enhancement therapy,`,
+            b: 'but I really think you should think twice about this enhancement therapy,',
         },
         {
             b: `It's all still pretty experimental.`,
@@ -68,17 +68,17 @@ const dialogueTrees: DialogueNpcTree[][] = [
             b: `so let me give a bit of advice for free: Size isn't everything.`,
         },
         {
-            a: `In my world it is. All the guys are getting it done.`,
+            a: 'In my world it is. All the guys are getting it done.',
         },
         {
             b: `Really? I didn't know that. And they are not having any problems?`,
         },
         {
-            b: `I mean... performing their duties so to speak.`,
+            b: 'I mean... performing their duties so to speak.',
         },
         {
             b_anim: 14,
-            a: `On the contrary, Sir. They are real beasts, all of them.`,
+            a: 'On the contrary, Sir. They are real beasts, all of them.',
         },
         {
             a: `Always at it, day and night. Really competing to see who's the biggest.`,
@@ -88,7 +88,7 @@ const dialogueTrees: DialogueNpcTree[][] = [
             b: `Wow. I mean... I don't judge, of course.`,
         },
         {
-            b: `I mean, this one time in military school. I mean, I was pretty drunk, of course...`,
+            b: 'I mean, this one time in military school. I mean, I was pretty drunk, of course...',
         },
         {
             a: `You're losing me, Sir. But can you get me those steroids or not?`,
@@ -98,29 +98,29 @@ const dialogueTrees: DialogueNpcTree[][] = [
         },
         {
             b_anim: 404,
-            b: `Steroids? Oh, steroids! I thought you were talking about something else...`,
+            b: 'Steroids? Oh, steroids! I thought you were talking about something else...',
         },
         {
-            a: `Losing me again, Sir. What did you think I was talking about?`,
+            a: 'Losing me again, Sir. What did you think I was talking about?',
         },
         {
             b: `Oh, nothing... I'll get you the damn steroids, don't worry.`,
         },
         {
-            a: `I mean, I thought I was pretty clear but... `,
+            a: 'I mean, I thought I was pretty clear but... ',
         },
         {
-            a: `Well you seem pretty fixated on guys, though. But you know,`,
+            a: 'Well you seem pretty fixated on guys, though. But you know,',
         },
         {
             a: `that's just fine. This is a medieval world we live in, and as far as I'm concerned,`,
         },
         {
-            a: `who you love is entirely up to you.`,
+            a: 'who you love is entirely up to you.',
         },
         {
             b_anim: 856,
-            b: `Shut up!`,
+            b: 'Shut up!',
         },
     ],
 ];
@@ -181,9 +181,7 @@ const npcIdleAction = (npc: Npc) => {
 };
 
 const guardInitAction: npcInitActionHandler = ({ npc }) => {
-    // this used to use `setInterval` but will need rewriting to be synced with ticks
-    // see https://github.com/runejs/server/issues/417
-    // setInterval(() => npcIdleAction(npc), (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH);
+    setInterval(() => npcIdleAction(npc), (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH);
 };
 
 export default {

--- a/src/plugins/npcs/lumbridge/hans.plugin.ts
+++ b/src/plugins/npcs/lumbridge/hans.plugin.ts
@@ -9,32 +9,35 @@ const handler = async ({ player, npc }) => {
     const dialogueParticipants = [player, { npc, key: 'hans' }];
 
     const dialogueTree = [
-        hans => [Emote.GENERIC, `Welcome to RuneJS!`],
-        (hans, tag_Hans_Question) => [
+        _hans => [Emote.GENERIC, 'Welcome to RuneJS!'],
+        (_hans, _tag_Hans_Question) => [
             Emote.HAPPY,
-            `How do you feel about RuneJS so far?\n` + `Please take a moment to let us know what you think!`,
+            'How do you feel about RuneJS so far?\n' + 'Please take a moment to let us know what you think!',
         ],
-        options => [
-            `Love it!`,
+        _options => [
+            'Love it!',
             [
-                player => [Emote.HAPPY, `Loving it so far, thanks for asking!`],
-                hans => [Emote.HAPPY, `You're very welcome! Glad to hear it.`],
+                _player => [Emote.HAPPY, 'Loving it so far, thanks for asking!'],
+                _hans => [Emote.HAPPY, `You're very welcome! Glad to hear it.`],
             ],
-            `Kind of cool.`,
+            'Kind of cool.',
             [
-                player => [Emote.GENERIC, `It's kind of cool, I guess. Bit of a weird gimmick.`],
-                hans => [Emote.HAPPY, `Please let us know if you have any suggestions.`],
+                _player => [Emote.GENERIC, `It's kind of cool, I guess. Bit of a weird gimmick.`],
+                _hans => [Emote.HAPPY, 'Please let us know if you have any suggestions.'],
             ],
-            `Not my cup of tea, honestly.`,
-            [player => [Emote.SKEPTICAL, `Not really my cup of tea, but keep at it.`], hans => [Emote.GENERIC, `Thanks for the support!`]],
+            'Not my cup of tea, honestly.',
+            [
+                _player => [Emote.SKEPTICAL, 'Not really my cup of tea, but keep at it.'],
+                _hans => [Emote.GENERIC, 'Thanks for the support!'],
+            ],
             `It's literally the worst.`,
             [
-                player => [Emote.ANGRY, `Literally the worst thing I've ever seen. You disgust me on a personal level.`],
-                hans => [Emote.SAD, `I-is that so?... Well I'm... I'm sorry to hear that.`],
+                _player => [Emote.ANGRY, `Literally the worst thing I've ever seen. You disgust me on a personal level.`],
+                _hans => [Emote.SAD, `I-is that so?... Well I'm... I'm sorry to hear that.`],
                 execute(() => (sadEnding = true)),
             ],
-            `What?`,
-            [player => [Emote.DROWZY, `What?...`], goto('tag_Hans_Question')],
+            'What?',
+            [_player => [Emote.DROWZY, 'What?...'], goto('tag_Hans_Question')],
         ],
     ];
 
@@ -46,10 +49,10 @@ const handler = async ({ player, npc }) => {
     if (dialogueSuccessful) {
         if (sadEnding) {
             npc.playAnimation(animationIds.cry);
-            npc.say(`Jerk!`);
-            player.sendMessage(`Hans wanders off rather dejectedly.`);
+            npc.say('Jerk!');
+            player.sendMessage('Hans wanders off rather dejectedly.');
         } else {
-            player.sendMessage(`Hans wanders off aimlessly through the courtyard.`);
+            player.sendMessage('Hans wanders off aimlessly through the courtyard.');
         }
 
         giveAchievement(Achievements.WELCOME, player);

--- a/src/plugins/npcs/lumbridge/lumbridge-farm-helpers.plugin.ts
+++ b/src/plugins/npcs/lumbridge/lumbridge-farm-helpers.plugin.ts
@@ -5,72 +5,72 @@ const millieDialogue: npcInteractionActionHandler = async details =>
     dialogue(
         [details.player, { npc: details.npc, key: 'millie' }],
         [
-            millie => [Emote.GENERIC, `Hello Adventurer. Welcome to Mill Lane Mill. Can I help you?`],
-            options => [
-                `Who are you?`,
+            _millie => [Emote.GENERIC, 'Hello Adventurer. Welcome to Mill Lane Mill. Can I help you?'],
+            _options => [
+                'Who are you?',
                 [
-                    player => [Emote.WONDERING, `Who are you?`],
-                    millie => [
+                    _player => [Emote.WONDERING, 'Who are you?'],
+                    _millie => [
                         Emote.HAPPY,
-                        `I'm Miss Millicent Miller the Miller of Mill Lane Mill. ` + `Our family have been milling flour for generations.`,
+                        `I'm Miss Millicent Miller the Miller of Mill Lane Mill. ` + 'Our family have been milling flour for generations.',
                     ],
-                    player => [Emote.GENERIC, `It's a good business to be in. People will always need flour.`],
+                    _player => [Emote.GENERIC, `It's a good business to be in. People will always need flour.`],
                     goto('tag_Mill_Flour'),
                 ],
-                `What is this place?`,
+                'What is this place?',
                 [
-                    player => [Emote.WONDERING, `What is this place?`],
-                    millie => [
+                    _player => [Emote.WONDERING, 'What is this place?'],
+                    _millie => [
                         Emote.HAPPY,
-                        `This is Mill Lane Mill. Millers of the finest flour in Gielinor, ` +
-                            `and home to the Miller family for many generations.`,
+                        'This is Mill Lane Mill. Millers of the finest flour in Gielinor, ' +
+                            'and home to the Miller family for many generations.',
                     ],
-                    millie => [Emote.GENERIC, `We take grain from the field nearby and mill into flour.`],
+                    _millie => [Emote.GENERIC, 'We take grain from the field nearby and mill into flour.'],
                     goto('tag_Mill_Flour'),
                 ],
-                `How do I mill flour?`,
+                'How do I mill flour?',
                 [
-                    (player, tag_Mill_Flour) => [Emote.WONDERING, `How do I mill flour?`],
-                    millie => [
+                    (_player, _tag_Mill_Flour) => [Emote.WONDERING, 'How do I mill flour?'],
+                    _millie => [
                         Emote.GENERIC,
-                        `Making flour is pretty easy. First of all you need to get some grain. ` +
-                            `You can pick some from wheat fields. There is one just outside the Mill, but there are ` +
-                            `many others scattered across Gielinor.`,
+                        'Making flour is pretty easy. First of all you need to get some grain. ' +
+                            'You can pick some from wheat fields. There is one just outside the Mill, but there are ' +
+                            'many others scattered across Gielinor.',
                     ],
-                    millie => [
+                    _millie => [
                         Emote.GENERIC,
-                        `Feel free to pick wheat from our field! There always seems to be plenty ` + `of wheat there.`,
+                        'Feel free to pick wheat from our field! There always seems to be plenty ' + 'of wheat there.',
                     ],
-                    player => [Emote.WONDERING, `Then I bring my wheat here?`],
-                    millie => [
+                    _player => [Emote.WONDERING, 'Then I bring my wheat here?'],
+                    _millie => [
                         Emote.GENERIC,
-                        `Yes, or one of the other mills in Gielinor. They all work the same way. ` +
-                            `Just take your grain to the top floor of the mill (up two ladders, there are three floors ` +
-                            `including this one) and then place some`,
+                        'Yes, or one of the other mills in Gielinor. They all work the same way. ' +
+                            'Just take your grain to the top floor of the mill (up two ladders, there are three floors ' +
+                            'including this one) and then place some',
                     ],
-                    millie => [
+                    _millie => [
                         Emote.GENERIC,
-                        `grain into the hopper. Then you need to start the grinding process by ` +
-                            `pulling the hopper lever. You can add more grain, but each time you add grain you have to ` +
-                            `pull the hopper lever again.`,
+                        'grain into the hopper. Then you need to start the grinding process by ' +
+                            'pulling the hopper lever. You can add more grain, but each time you add grain you have to ' +
+                            'pull the hopper lever again.',
                     ],
-                    player => [Emote.WONDERING, `So where does the flour go then?`],
-                    millie => [
+                    _player => [Emote.WONDERING, 'So where does the flour go then?'],
+                    _millie => [
                         Emote.GENERIC,
                         `The flour appears in this room here, you'll need a pot to put the flour ` +
-                            `into. One pot will hold the flour made by one load of grain`,
+                            'into. One pot will hold the flour made by one load of grain',
                     ],
-                    millie => [
+                    _millie => [
                         Emote.GENERIC,
                         `And that's it! You now have some pots of finely ground flour of the ` +
                             `highest quality. Ideal for making tasty cakes or delicous bread. I'm not a cook so you'll ` +
-                            `have to ask a cook to find`,
+                            'have to ask a cook to find',
                     ],
-                    millie => [Emote.GENERIC, `out how to bake things.`],
-                    player => [Emote.HAPPY, `Great! Thanks for your help.`],
+                    _millie => [Emote.GENERIC, 'out how to bake things.'],
+                    _player => [Emote.HAPPY, 'Great! Thanks for your help.'],
                 ],
                 `I'm fine, thanks.`,
-                [player => [Emote.GENERIC, `I'm fine, thanks.`]],
+                [_player => [Emote.GENERIC, `I'm fine, thanks.`]],
             ],
         ],
     );
@@ -79,37 +79,37 @@ const gillieDialogue: npcInteractionActionHandler = async details =>
     dialogue(
         [details.player, { npc: details.npc, key: 'gillie' }],
         [
-            gillie => [Emote.HAPPY, `Hello, I'm Gillie the Milkmaid. What can I do for you?`],
-            options => [
-                `Who are you?`,
+            _gillie => [Emote.HAPPY, `Hello, I'm Gillie the Milkmaid. What can I do for you?`],
+            _options => [
+                'Who are you?',
                 [
-                    player => [Emote.WONDERING, `Who are you?`],
-                    gillie => [Emote.GENERIC, `My name is Gillie Groats. My father is a farmer and I milk the cows for him.`],
-                    player => [Emote.WONDERING, `Do you have nay buckets of milk spare?`],
-                    gillie => [
+                    _player => [Emote.WONDERING, 'Who are you?'],
+                    _gillie => [Emote.GENERIC, 'My name is Gillie Groats. My father is a farmer and I milk the cows for him.'],
+                    _player => [Emote.WONDERING, 'Do you have nay buckets of milk spare?'],
+                    _gillie => [
                         Emote.GENERIC,
                         `I'm afraid not. We need all of our milk to sell to market, ` +
-                            `but you can milk the cow yourself if you need the milk.`,
+                            'but you can milk the cow yourself if you need the milk.',
                     ],
-                    player => [Emote.GENERIC, `Thanks.`],
+                    _player => [Emote.GENERIC, 'Thanks.'],
                 ],
-                `So how do you milk a cow then?`,
+                'So how do you milk a cow then?',
                 [
-                    player => [Emote.WONDERING, `So how do you milk a cow then?`],
-                    gillie => [Emote.HAPPY, `It's very easy. First you need an empty bucket to hold the milk.`],
-                    gillie => [Emote.HAPPY, `Then find a dairy cow to milk - you can't milk just any cow.`],
-                    player => [Emote.SKEPTICAL, `How do I find a dairy cow?`],
-                    gillie => [
+                    _player => [Emote.WONDERING, 'So how do you milk a cow then?'],
+                    _gillie => [Emote.HAPPY, `It's very easy. First you need an empty bucket to hold the milk.`],
+                    _gillie => [Emote.HAPPY, `Then find a dairy cow to milk - you can't milk just any cow.`],
+                    _player => [Emote.SKEPTICAL, 'How do I find a dairy cow?'],
+                    _gillie => [
                         Emote.GENERIC,
-                        `They are easy to spot - they are dark brown and white, unlike ` +
-                            `beef cows, which are light brown and white. We also tether them to a post to stop them ` +
-                            `wandering around all over the place.`,
+                        'They are easy to spot - they are dark brown and white, unlike ' +
+                            'beef cows, which are light brown and white. We also tether them to a post to stop them ' +
+                            'wandering around all over the place.',
                     ],
-                    gillie => [Emote.GENERIC, `There are a couple very near, in this field.`],
-                    gillie => [Emote.GENERIC, `Then just milk the cow and your bucket will fill with tasty, untritious milk.`],
+                    _gillie => [Emote.GENERIC, 'There are a couple very near, in this field.'],
+                    _gillie => [Emote.GENERIC, 'Then just milk the cow and your bucket will fill with tasty, untritious milk.'],
                 ],
                 `I'm fine, thanks.`,
-                [player => [Emote.GENERIC, `I'm fine, thanks.`]],
+                [_player => [Emote.GENERIC, `I'm fine, thanks.`]],
             ],
         ],
     );

--- a/src/plugins/npcs/port-sarim/betty.plugin.ts
+++ b/src/plugins/npcs/port-sarim/betty.plugin.ts
@@ -5,24 +5,23 @@ import { Emote, dialogue, execute } from '@engine/world/actor/dialogue';
 const shopAction: npcInteractionActionHandler = details => findShop('rs:bettys_magic_emporium')?.open(details.player);
 
 const dialogueAction: npcInteractionActionHandler = details => {
-    const { player, npc } = details;
     let openShop = false;
     dialogue(
         [details.player, { npc: details.npc, key: 'betty' }],
         [
-            betty => [Emote.HAPPY, `Welcome to the magic emporium.`],
-            options => [
-                `Can I see your wares?`,
+            _betty => [Emote.HAPPY, 'Welcome to the magic emporium.'],
+            _options => [
+                'Can I see your wares?',
                 [
-                    player => [Emote.HAPPY, `Can I see your wares?`],
+                    _player => [Emote.HAPPY, 'Can I see your wares?'],
                     execute(() => {
                         openShop = true;
                     }),
                 ],
                 `Sorry I'm not into magic.`,
                 [
-                    player => [Emote.GENERIC, `Sorry I'm not into magic.`],
-                    betty => [Emote.HAPPY, `Well, if you see anyone who is into magic, please send them my way.`],
+                    _player => [Emote.GENERIC, `Sorry I'm not into magic.`],
+                    _betty => [Emote.HAPPY, 'Well, if you see anyone who is into magic, please send them my way.'],
                 ],
             ],
         ],

--- a/src/plugins/npcs/varrock/blue-moon-inn.plugin.ts
+++ b/src/plugins/npcs/varrock/blue-moon-inn.plugin.ts
@@ -9,12 +9,12 @@ const talkToBartender: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'bartender' }],
         [
-            bartender => [Emote.HAPPY, 'What can I do yer for?'],
-            options => [
-                `A glass of your finest ale please.`,
+            _bartender => [Emote.HAPPY, 'What can I do yer for?'],
+            _options => [
+                'A glass of your finest ale please.',
                 [
-                    player => [Emote.HAPPY, `A glass of your finest ale please.`],
-                    bartender => [Emote.HAPPY, `No problemo. That'll be 2 coins.`],
+                    _player => [Emote.HAPPY, 'A glass of your finest ale please.'],
+                    _bartender => [Emote.HAPPY, `No problemo. That'll be 2 coins.`],
                     execute(() => {
                         const index = player.inventory.findIndex(itemIds.coins);
                         const hasCoins = player.inventory.has(itemIds.coins);
@@ -22,7 +22,7 @@ const talkToBartender: npcInteractionActionHandler = details => {
                         if (!hasCoins) {
                             dialogue(
                                 [player, { npc, key: 'bartender' }],
-                                [player => [Emote.VERY_SAD, `Oh dear. I don't seem to have enough money.`]],
+                                [_player => [Emote.VERY_SAD, `Oh dear. I don't seem to have enough money.`]],
                             );
                         }
 
@@ -49,38 +49,38 @@ const talkToBartender: npcInteractionActionHandler = details => {
                         }
                     }),
                 ],
-                `Can you recommend where an adventurer might make his fortune?`,
+                'Can you recommend where an adventurer might make his fortune?',
                 [
-                    player => [Emote.WONDERING, `Can you recommend where an adventurer might make his fortune?`],
-                    bartender => [Emote.LAUGH, `Ooh I don't know if I should be giving away information, makes the game too easy.`],
-                    options => [
-                        `Oh ah well...`,
-                        [player => [Emote.WORRIED, `Oh ah well...`]],
-                        `Game? What are you talking about?`,
+                    _player => [Emote.WONDERING, 'Can you recommend where an adventurer might make his fortune?'],
+                    _bartender => [Emote.LAUGH, `Ooh I don't know if I should be giving away information, makes the game too easy.`],
+                    _options => [
+                        'Oh ah well...',
+                        [_player => [Emote.WORRIED, 'Oh ah well...']],
+                        'Game? What are you talking about?',
                         [
-                            player => [Emote.WORRIED, `Game? What are you talking about?`],
-                            bartender => [Emote.GENERIC, `This world around us... is an online game... called Old School RuneScape.`],
-                            player => [Emote.GENERIC, `Nope, still don't understand what you are talking about. What does 'online' mean?`],
-                            bartender => [
+                            _player => [Emote.WORRIED, 'Game? What are you talking about?'],
+                            _bartender => [Emote.GENERIC, 'This world around us... is an online game... called Old School RuneScape.'],
+                            _player => [Emote.GENERIC, `Nope, still don't understand what you are talking about. What does 'online' mean?`],
+                            _bartender => [
                                 Emote.GENERIC,
                                 `It's a sort of connection between magic boxes across the world, big boxes on people's desktops and little ones people can carry. They can talk to each other to play games.`,
                             ],
-                            player => [Emote.GENERIC, `I give up. You're obviously completely mad!`],
+                            _player => [Emote.GENERIC, `I give up. You're obviously completely mad!`],
                         ],
-                        `Just a small clue?`,
+                        'Just a small clue?',
                         [
-                            player => [Emote.WONDERING, `Just a small clue?`],
-                            bartender => [
+                            _player => [Emote.WONDERING, 'Just a small clue?'],
+                            _bartender => [
                                 Emote.VERY_SAD,
                                 `Go and talk to the bartender at the Jolly Boar Inn, he doesn't seem to mind giving away clues.`,
                             ],
                         ],
                     ],
                 ],
-                `Do you know where I can get some good equipment?`,
+                'Do you know where I can get some good equipment?',
                 [
-                    player => [Emote.WONDERING, `Do you know where I can get some good equipment?`],
-                    bartender => [
+                    _player => [Emote.WONDERING, 'Do you know where I can get some good equipment?'],
+                    _bartender => [
                         Emote.HAPPY,
                         `Well, there's the sword shop across the road, or there's also all sorts of shops up around the market.`,
                     ],
@@ -96,12 +96,12 @@ const talkToCook: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'cook' }],
         [
-            cook => [Emote.ANGRY, `What do you want? I'm busy!`],
-            options => [
-                `Can you sell me any food?`,
+            _cook => [Emote.ANGRY, `What do you want? I'm busy!`],
+            _options => [
+                'Can you sell me any food?',
                 [
-                    player => [Emote.WONDERING, `Can you sell me any food?`],
-                    cook => [
+                    _player => [Emote.WONDERING, 'Can you sell me any food?'],
+                    _cook => [
                         Emote.GENERIC,
                         `I suppose I could sell you some cabbage, if you're willing to pay for it. Cabbage is good for you.`,
                     ],
@@ -114,8 +114,8 @@ const talkToCook: npcInteractionActionHandler = details => {
                             dialogue(
                                 [player, { npc, key: 'cook' }],
                                 [
-                                    player => [Emote.VERY_SAD, `Oh, I haven't got any money.`],
-                                    cook => [Emote.ANGRY, `Why are you asking me to sell you food if you haven't got any money? Go away!`],
+                                    _player => [Emote.VERY_SAD, `Oh, I haven't got any money.`],
+                                    _cook => [Emote.ANGRY, `Why are you asking me to sell you food if you haven't got any money? Go away!`],
                                 ],
                             );
                         }
@@ -126,10 +126,10 @@ const talkToCook: npcInteractionActionHandler = details => {
                             dialogue(
                                 [player, { npc, key: 'cook' }],
                                 [
-                                    options => [
+                                    _options => [
                                         `Alright I'll buy a cabbage.`,
                                         [
-                                            player => [Emote.HAPPY, `Alright I'll buy a cabbage.`],
+                                            _player => [Emote.HAPPY, `Alright I'll buy a cabbage.`],
                                             execute(() => {
                                                 // Check inventory.
                                                 if (!player.inventory.hasSpace()) {
@@ -150,15 +150,15 @@ const talkToCook: npcInteractionActionHandler = details => {
                                                 player.inventory.add(itemIds.cabbage);
                                                 player.outgoingPackets.sendUpdateAllWidgetItems(widgets.inventory, player.inventory);
                                             }),
-                                            cook => [
+                                            _cook => [
                                                 Emote.HAPPY,
                                                 `It's a deal. Now, make sure you eat it all up. Cabbage is good for you.`,
                                             ],
                                         ],
                                         `No thanks, I don't like cabbage.`,
                                         [
-                                            player => [Emote.GENERIC, `No thanks, I don't like cabbage.`],
-                                            cook => [Emote.SAD, `Bah! People these days only appreciate junk food.`],
+                                            _player => [Emote.GENERIC, `No thanks, I don't like cabbage.`],
+                                            _cook => [Emote.SAD, 'Bah! People these days only appreciate junk food.'],
                                         ],
                                     ],
                                 ],
@@ -166,22 +166,22 @@ const talkToCook: npcInteractionActionHandler = details => {
                         }
                     }),
                 ],
-                `Can you give any free food?`,
+                'Can you give any free food?',
                 [
                     // PLAYER: Can you give any free food?
-                    player => [Emote.GENERIC, `Can you give any free food?`],
-                    cook => [Emote.GENERIC, `Can you give my any free money?`],
-                    player => [Emote.GENERIC, `Why should I give you free money?`],
-                    cook => [Emote.GENERIC, `Why should I give you free food?`],
-                    player => [Emote.GENERIC, `Oh, forget it.`],
+                    _player => [Emote.GENERIC, 'Can you give any free food?'],
+                    _cook => [Emote.GENERIC, 'Can you give my any free money?'],
+                    _player => [Emote.GENERIC, 'Why should I give you free money?'],
+                    _cook => [Emote.GENERIC, 'Why should I give you free food?'],
+                    _player => [Emote.GENERIC, 'Oh, forget it.'],
                 ],
                 `I don't want anything from this horrible kitchen.`,
                 [
-                    player => [Emote.SHOCKED, `I don't want anything from this horrible kitchen.`],
-                    cook => [Emote.ANGRY, `How dare you? I put a lot of effort into cleaning this kitchen.`],
-                    cook => [Emote.ANGRY, `My daily sweat and elbow-grease keep this kitchen clean!`],
-                    player => [Emote.GENERIC, `Ewww!`],
-                    cook => [Emote.SAD, `Oh, just leave me alone.`],
+                    _player => [Emote.SHOCKED, `I don't want anything from this horrible kitchen.`],
+                    _cook => [Emote.ANGRY, 'How dare you? I put a lot of effort into cleaning this kitchen.'],
+                    _cook => [Emote.ANGRY, 'My daily sweat and elbow-grease keep this kitchen clean!'],
+                    _player => [Emote.GENERIC, 'Ewww!'],
+                    _cook => [Emote.SAD, 'Oh, just leave me alone.'],
                 ],
             ],
         ],

--- a/src/plugins/npcs/varrock/master-smithing-tutor.plugin.ts
+++ b/src/plugins/npcs/varrock/master-smithing-tutor.plugin.ts
@@ -8,69 +8,69 @@ const talkTo: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'tutor' }],
         [
-            player => [Emote.GENERIC, `Hello.`],
-            tutor => [Emote.GENERIC, `Well met! Are you interested in hearing about the art of smithing?`],
-            options => [
-                `How can I train my smithing?`,
+            _player => [Emote.GENERIC, 'Hello.'],
+            _tutor => [Emote.GENERIC, 'Well met! Are you interested in hearing about the art of smithing?'],
+            _options => [
+                'How can I train my smithing?',
                 [
-                    (player, tag_how_to_train) => [Emote.WONDERING, `How can I train my smithing?`],
-                    tutor => [Emote.GENERIC, `To be able to smith anything, you're going to need one of these beauties.`],
+                    (_player, _tag_how_to_train) => [Emote.WONDERING, 'How can I train my smithing?'],
+                    _tutor => [Emote.GENERIC, `To be able to smith anything, you're going to need one of these beauties.`],
                     execute(() => {
                         player.inventory.add(itemIds.hammer);
                         player.sendMessage('The Master Smithing Tutor gives you a hammer.', true);
                         player.outgoingPackets.sendUpdateAllWidgetItems(widgets.inventory, player.inventory);
                     }),
-                    tutor => [Emote.GENERIC, `You're going to get your hand on some metal bars.`],
-                    tutor => [Emote.GENERIC, `You could do this by mining your own ores and smelting them at a furnace.`],
-                    tutor => [Emote.GENERIC, `There is a furnace in Lumbridge, just north of the castle opposite the general store.`],
-                    tutor => [Emote.GENERIC, `If you are looking for some ore, there is a mine east of Varrock.`],
-                    tutor => [Emote.GENERIC, `There you can find some copper and tin ore. Don't forget to bring a pickaxe.`],
-                    tutor => [Emote.GENERIC, `When you have your bars, bring them to an anvil to open the smithing interface.`],
-                    tutor => [Emote.GENERIC, `If the item name is in black, this means you do not have the level to smith the item.`],
-                    tutor => [Emote.GENERIC, `If the name is in white, this means you have the level to smith the item.`],
-                    tutor => [Emote.GENERIC, `You will see the bars required to smith the item underneath the name of the item.`],
-                    tutor => [
+                    _tutor => [Emote.GENERIC, `You're going to get your hand on some metal bars.`],
+                    _tutor => [Emote.GENERIC, 'You could do this by mining your own ores and smelting them at a furnace.'],
+                    _tutor => [Emote.GENERIC, 'There is a furnace in Lumbridge, just north of the castle opposite the general store.'],
+                    _tutor => [Emote.GENERIC, 'If you are looking for some ore, there is a mine east of Varrock.'],
+                    _tutor => [Emote.GENERIC, `There you can find some copper and tin ore. Don't forget to bring a pickaxe.`],
+                    _tutor => [Emote.GENERIC, 'When you have your bars, bring them to an anvil to open the smithing interface.'],
+                    _tutor => [Emote.GENERIC, 'If the item name is in black, this means you do not have the level to smith the item.'],
+                    _tutor => [Emote.GENERIC, 'If the name is in white, this means you have the level to smith the item.'],
+                    _tutor => [Emote.GENERIC, 'You will see the bars required to smith the item underneath the name of the item.'],
+                    _tutor => [
                         Emote.GENERIC,
-                        `If the number of bars is in orange, this means that you do not have enough bars to smith the item.`,
+                        'If the number of bars is in orange, this means that you do not have enough bars to smith the item.',
                     ],
-                    tutor => [Emote.GENERIC, `If it is in green, this means you have enough bars for the item.`],
-                    player => [Emote.GENERIC, `Thanks for the advice.`],
-                    options => [
-                        `What kinds of things can I smith?`,
+                    _tutor => [Emote.GENERIC, 'If it is in green, this means you have enough bars for the item.'],
+                    _player => [Emote.GENERIC, 'Thanks for the advice.'],
+                    _options => [
+                        'What kinds of things can I smith?',
                         [goto('tag_what_kinds')],
-                        `Not right now, thank you.`,
+                        'Not right now, thank you.',
                         [goto('tag_no_thanks')],
                     ],
                 ],
-                `What kinds of things can I smith?`,
+                'What kinds of things can I smith?',
                 [
-                    (player, tag_what_kinds) => [Emote.WONDERING, `What kinds of things can I smith?`],
-                    tutor => [Emote.GENERIC, `There are many things you can make, from weapons to your good old fashioned armour.`],
-                    tutor => [
+                    (_player, _tag_what_kinds) => [Emote.WONDERING, 'What kinds of things can I smith?'],
+                    _tutor => [Emote.GENERIC, 'There are many things you can make, from weapons to your good old fashioned armour.'],
+                    _tutor => [
                         Emote.GENERIC,
-                        `Weapons are the cheapest things to smith. They range from a measly one bar, all the way to three bars.`,
+                        'Weapons are the cheapest things to smith. They range from a measly one bar, all the way to three bars.',
                     ],
-                    tutor => [
+                    _tutor => [
                         Emote.GENERIC,
-                        `Armour can be the costliest item to smith, the cost of each item ranges from a measly one bar all the way up to a whopping five bars.`,
+                        'Armour can be the costliest item to smith, the cost of each item ranges from a measly one bar all the way up to a whopping five bars.',
                     ],
-                    tutor => [
+                    _tutor => [
                         Emote.GENERIC,
-                        `Some weapons and armours, such as darts, will require you to have gained knowledge on how to smith them.`,
+                        'Some weapons and armours, such as darts, will require you to have gained knowledge on how to smith them.',
                     ],
-                    tutor => [Emote.GENERIC, `This is due to the complex nature of the weapon.`],
-                    tutor => [Emote.GENERIC, `You might find other items don't require conventional bars you would gather.`],
-                    tutor => [
+                    _tutor => [Emote.GENERIC, 'This is due to the complex nature of the weapon.'],
+                    _tutor => [Emote.GENERIC, `You might find other items don't require conventional bars you would gather.`],
+                    _tutor => [
                         Emote.GENERIC,
-                        `Some may require you to piece back together or even infuse a crystal into a piece of armour.`,
+                        'Some may require you to piece back together or even infuse a crystal into a piece of armour.',
                     ],
-                    tutor => [Emote.GENERIC, `Is there anything else you want to know?`],
-                    options => [`How can i train my smithing?`, [goto('tag_how_to_train')], `No, thank you.`, [goto('tag_no_thanks')]],
+                    _tutor => [Emote.GENERIC, 'Is there anything else you want to know?'],
+                    _options => ['How can i train my smithing?', [goto('tag_how_to_train')], 'No, thank you.', [goto('tag_no_thanks')]],
                 ],
-                `Not right now, thank you.`,
+                'Not right now, thank you.',
                 [
-                    (player, tag_no_thanks) => [Emote.GENERIC, `Not right now, thank you.`],
-                    tutor => [Emote.GENERIC, `Well, just come back any time you want to know anything!`],
+                    (_player, _tag_no_thanks) => [Emote.GENERIC, 'Not right now, thank you.'],
+                    _tutor => [Emote.GENERIC, 'Well, just come back any time you want to know anything!'],
                 ],
             ],
         ],

--- a/src/plugins/npcs/varrock/wilough.plugin.ts
+++ b/src/plugins/npcs/varrock/wilough.plugin.ts
@@ -9,12 +9,12 @@ const talkTo: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'wilough' }, { npc: shilop.gameId, key: 'shilop' }],
         [
-            player => [Emote.GENERIC, `Hello again.`],
-            wilough => [Emote.GENERIC, `You think you're tough do you?`],
-            player => [Emote.GENERIC, `Pardon?`],
-            wilough => [Emote.ANGRY, `I can beat anyone up!`],
-            shilop => [Emote.BLANK_STARE, `He can you know!`],
-            player => [Emote.BLANK_STARE, `Really?`],
+            _player => [Emote.GENERIC, 'Hello again.'],
+            _wilough => [Emote.GENERIC, `You think you're tough do you?`],
+            _player => [Emote.GENERIC, 'Pardon?'],
+            _wilough => [Emote.ANGRY, 'I can beat anyone up!'],
+            _shilop => [Emote.BLANK_STARE, 'He can you know!'],
+            _player => [Emote.BLANK_STARE, 'Really?'],
         ],
     );
 };

--- a/src/plugins/npcs/varrock/zaff-superior-staffs.plugin.ts
+++ b/src/plugins/npcs/varrock/zaff-superior-staffs.plugin.ts
@@ -10,9 +10,9 @@ const talkToAction: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'zaff' }],
         [
-            zaff => [Emote.GENERIC, `Would you like to buy or sell some staffs?`],
-            options => [
-                `Yes, please!`,
+            _zaff => [Emote.GENERIC, 'Would you like to buy or sell some staffs?'],
+            _options => [
+                'Yes, please!',
                 [
                     execute(() => {
                         tradeAction(details);
@@ -21,8 +21,8 @@ const talkToAction: npcInteractionActionHandler = details => {
 
                 'Have you any extra stock of battlestaffs I can buy?',
                 [
-                    player => [Emote.GENERIC, 'Have you any extra stock of battlestaffs I can buy?'],
-                    zaff => [Emote.WONDERING, "No, I'm afraid I can't help you."],
+                    _player => [Emote.GENERIC, 'Have you any extra stock of battlestaffs I can buy?'],
+                    _zaff => [Emote.WONDERING, "No, I'm afraid I can't help you."],
                     execute(() => {
                         player.sendMessage(
                             "You must complete the Varrock Achievement Diary before you can access Zaff's extra battlestaff stock.",
@@ -32,9 +32,9 @@ const talkToAction: npcInteractionActionHandler = details => {
 
                 'No, thank you.',
                 [
-                    player => [Emote.GENERIC, 'No, thank you.'],
-                    zaff => [Emote.GENERIC, "Well 'stick' your head in if you change your mind."],
-                    player => [Emote.GENERIC, "Huh, terrible pun! You just can't get the 'staff' these days!"],
+                    _player => [Emote.GENERIC, 'No, thank you.'],
+                    _zaff => [Emote.GENERIC, "Well 'stick' your head in if you change your mind."],
+                    _player => [Emote.GENERIC, "Huh, terrible pun! You just can't get the 'staff' these days!"],
                 ],
             ],
         ],

--- a/src/plugins/objects/bank/bank.plugin.ts
+++ b/src/plugins/objects/bank/bank.plugin.ts
@@ -268,8 +268,8 @@ const useBankBoothAction: objectInteractionActionHandler = async details => {
     await dialogue(
         [player, { npc: 'rs:generic_banker', key: 'banker' }],
         [
-            banker => [Emote.HAPPY, `Good day, how can I help you?`],
-            options => [
+            _banker => [Emote.HAPPY, 'Good day, how can I help you?'],
+            _options => [
                 `I'd Like to access my bank account, please.`,
                 [
                     execute(() => {
@@ -282,13 +282,13 @@ const useBankBoothAction: objectInteractionActionHandler = async details => {
                         openPin = true;
                     }),
                 ],
-                `What is this place?`,
+                'What is this place?',
                 [
-                    player => [Emote.WONDERING, `What is this place?`],
-                    banker => [Emote.HAPPY, `This is a branch of the Bank of Gielinor. We have branches in many towns.`],
-                    player => [Emote.WONDERING, `And what do you do?`],
-                    banker => [Emote.GENERIC, `We will look after your items and money for you.`],
-                    banker => [Emote.GENERIC, `Leave your valuables with us if you want to keep them safe.`],
+                    _player => [Emote.WONDERING, 'What is this place?'],
+                    _banker => [Emote.HAPPY, 'This is a branch of the Bank of Gielinor. We have branches in many towns.'],
+                    _player => [Emote.WONDERING, 'And what do you do?'],
+                    _banker => [Emote.GENERIC, 'We will look after your items and money for you.'],
+                    _banker => [Emote.GENERIC, 'Leave your valuables with us if you want to keep them safe.'],
                 ],
             ],
         ],

--- a/src/plugins/objects/crates/crates.plugin.ts
+++ b/src/plugins/objects/crates/crates.plugin.ts
@@ -1,6 +1,7 @@
 import type { objectInteractionActionHandler } from '@engine/action/pipe/object-interaction.action';
 import { findItem, widgets } from '@engine/config/config-handler';
 import { itemIds } from '@engine/world/config/item-ids';
+import { World } from '@engine/world/world';
 
 export const action: objectInteractionActionHandler = details => {
     const veggies = [itemIds.onion, itemIds.grain, itemIds.cabbage];
@@ -12,16 +13,13 @@ export const action: objectInteractionActionHandler = details => {
 
     details.player.outgoingPackets.sendUpdateAllWidgetItems(widgets.inventory, details.player.inventory);
 
-    // this used to use `setInterval` but will need rewriting to be synced with ticks
-    // see https://github.com/runejs/server/issues/417
-    details.player.sendMessage('[debug] see issue #417');
-    // setTimeout(() => {
-    //     details.player.sendMessage(`You found a ${pickedItem.name.toLowerCase()} chest!.`);
-    //     details.player.playSound(2581, 7);
-    //     details.player.instance.hideGameObjectTemporarily(details.object, 60);
-    //     details.player.giveItem(pickedItem.gameId);
-    //     details.player.busy = false;
-    // }, World.TICK_LENGTH);
+    setTimeout(() => {
+        details.player.sendMessage(`You found a ${pickedItem.name.toLowerCase()} chest!.`);
+        details.player.playSound(2581, 7);
+        details.player.instance.hideGameObjectTemporarily(details.object, 60);
+        details.player.giveItem(pickedItem.gameId);
+        details.player.busy = false;
+    }, World.TICK_LENGTH);
 };
 
 export default {

--- a/src/plugins/objects/item-spawns/take-axe.plugin.ts
+++ b/src/plugins/objects/item-spawns/take-axe.plugin.ts
@@ -18,12 +18,12 @@ export const action: objectInteractionActionHandler = details => {
     switch (option) {
         case 'take-axe':
             player.playAnimation(827);
-            player.sendMessage(`You take the axe.`);
+            player.sendMessage('You take the axe.');
             player.playSound(2581, 7);
             player.giveItem(itemMappings[details.object.objectId]);
             return;
         default:
-            player.sendMessage(`This has not been implemented.`);
+            player.sendMessage('This has not been implemented.');
             return;
     }
 };

--- a/src/plugins/objects/mill/flour-bin.plugin.ts
+++ b/src/plugins/objects/mill/flour-bin.plugin.ts
@@ -13,7 +13,7 @@ function flourBin(details: { objectConfig: ObjectConfig; player: Player }): void
         player.sendMessage(
             `The ${(objectConfig.name || '').toLowerCase()} is already empty. You need to place wheat in the hopper upstairs `,
         );
-        player.sendMessage(`first.`);
+        player.sendMessage('first.');
     } else {
         if (player.hasItemInInventory(itemIds.pot)) {
             player.playSound(soundIds.potContentModified, 7);
@@ -21,7 +21,7 @@ function flourBin(details: { objectConfig: ObjectConfig; player: Player }): void
             player.giveItem(itemIds.potOfFlour);
             details.player.savedMetadata['mill-flour'] -= 1;
         } else {
-            player.sendMessage(`You need a pot to hold the flour in.`);
+            player.sendMessage('You need a pot to hold the flour in.');
         }
     }
 

--- a/src/plugins/objects/mill/hopper.plugin.ts
+++ b/src/plugins/objects/mill/hopper.plugin.ts
@@ -3,7 +3,7 @@ import { itemIds } from '@engine/world/config/item-ids';
 
 export const action: itemOnObjectActionHandler = details => {
     if (details.player.savedMetadata['mill-grain'] && details.player.savedMetadata['mill-grain'] === 1) {
-        details.player.sendMessage(`There is already grain in the hopper.`);
+        details.player.sendMessage('There is already grain in the hopper.');
         return;
     }
     details.player.busy = true;

--- a/src/plugins/objects/pickables/pickables.plugin.ts
+++ b/src/plugins/objects/pickables/pickables.plugin.ts
@@ -1,6 +1,7 @@
 import type { objectInteractionActionHandler } from '@engine/action/pipe/object-interaction.action';
 import { findItem } from '@engine/config/config-handler';
 import { itemIds } from '@engine/world/config/item-ids';
+import { World } from '@engine/world/world';
 import { logger } from '@runejs/common';
 
 export const action: objectInteractionActionHandler = details => {
@@ -36,18 +37,17 @@ export const action: objectInteractionActionHandler = details => {
         return;
     }
 
-    // this used to use `setInterval` but will need rewriting to be synced with ticks
-    // see https://github.com/runejs/server/issues/417
-    details.player.sendMessage('[debug] see issue #417');
-    // setTimeout(() => {
-    //     details.player.sendMessage(`You ${details.option} the ${(details.objectConfig.name || '').toLowerCase()} and receive ${prefix} ${pickedItem.name.toLowerCase()}.`);
-    //     details.player.playSound(2581, 7);
-    //     if (details.objectConfig.name !== 'Flax' || Math.floor(Math.random() * 10) === 1) {
-    //         details.player.instance.hideGameObjectTemporarily(details.object, 30);
-    //     }
-    //     details.player.giveItem(pickedItem.gameId);
-    //     details.player.busy = false;
-    // }, World.TICK_LENGTH);
+    setTimeout(() => {
+        details.player.sendMessage(
+            `You ${details.option} the ${(details.objectConfig.name || '').toLowerCase()} and receive ${prefix} ${pickedItem.name.toLowerCase()}.`,
+        );
+        details.player.playSound(2581, 7);
+        if (details.objectConfig.name !== 'Flax' || Math.floor(Math.random() * 10) === 1) {
+            details.player.instance.hideGameObjectTemporarily(details.object, 30);
+        }
+        details.player.giveItem(pickedItem.gameId);
+        details.player.busy = false;
+    }, World.TICK_LENGTH);
 };
 
 export default {

--- a/src/plugins/quests/cooks-assistant-quest.plugin.ts
+++ b/src/plugins/quests/cooks-assistant-quest.plugin.ts
@@ -13,32 +13,32 @@ const journalHandler: QuestJournalHandler = {
     50: player => {
         let questLog =
             `It's the <col=800000>Duke of Lumbridge's</col> birthday and I have to help ` +
-            `his <col=800000>Cook</col> make him a <col=800000>birthday cake.</col> To do this I need to ` +
-            `bring him the following ingredients:\n`;
+            'his <col=800000>Cook</col> make him a <col=800000>birthday cake.</col> To do this I need to ' +
+            'bring him the following ingredients:\n';
 
         const quest = player.getQuest('rs:cooks_assistant');
 
         if (player.hasItemInInventory(itemIds.bucketOfMilk) || quest.metadata.givenMilk) {
-            questLog += `I have found a <col=800000>bucket of milk</col> to give to the cook.\n`;
+            questLog += 'I have found a <col=800000>bucket of milk</col> to give to the cook.\n';
         } else {
             questLog +=
                 `I need to find a <col=800000>bucket of milk.</col> There's a cattle field east ` +
-                `of Lumbridge, I should make sure I take an empty bucket with me.\n`;
+                'of Lumbridge, I should make sure I take an empty bucket with me.\n';
         }
 
         if (player.hasItemInInventory(itemIds.potOfFlour) || quest.metadata.givenFlour) {
-            questLog += `I have found a <col=800000>pot of flour</col> to give to the cook.\n`;
+            questLog += 'I have found a <col=800000>pot of flour</col> to give to the cook.\n';
         } else {
             questLog +=
                 `I need to find a <col=800000>pot of flour.</col> There's a mill found north-` +
-                `west of Lumbridge, I should take an empty pot with me.\n`;
+                'west of Lumbridge, I should take an empty pot with me.\n';
         }
 
         if (player.hasItemInInventory(itemIds.egg) || quest.metadata.givenEgg) {
-            questLog += `I have found an <col=800000>egg</col> to give to the cook.\n`;
+            questLog += 'I have found an <col=800000>egg</col> to give to the cook.\n';
         } else {
             questLog +=
-                `I need to find an <col=800000>egg.</col> The cook normally gets his eggs from ` +
+                'I need to find an <col=800000>egg.</col> The cook normally gets his eggs from ' +
                 `the Groats' farm, found just to the west of the cattle field.`;
         }
 
@@ -47,48 +47,51 @@ const journalHandler: QuestJournalHandler = {
 
     complete:
         `It was the Duke of Lumbridge's birthday, but his cook had ` +
-        `forgotten to buy the ingredients he needed to make him a ` +
-        `cake. I brought the cook an egg, some flour and some milk ` +
-        `and the cook made a delicious looking cake with them.\n\n` +
-        `As a reward he now lets me use his high quality range ` +
-        `which lets me burn things less whenever I wish to cook ` +
-        `there.\n\n` +
-        `<col=ff0000>QUEST COMPLETE!</col>`,
+        'forgotten to buy the ingredients he needed to make him a ' +
+        'cake. I brought the cook an egg, some flour and some milk ' +
+        'and the cook made a delicious looking cake with them.\n\n' +
+        'As a reward he now lets me use his high quality range ' +
+        'which lets me burn things less whenever I wish to cook ' +
+        'there.\n\n' +
+        '<col=ff0000>QUEST COMPLETE!</col>',
 };
 
 function dialogueIngredientQuestions(): Function {
-    return (options, tag_INGREDIENT_QUESTIONS) => [
-        `Where do I find some flour?`,
+    return (_options, _tag_INGREDIENT_QUESTIONS) => [
+        'Where do I find some flour?',
         [
-            player => [Emote.GENERIC, `Where do I find some flour?`],
-            cook => [
+            _player => [Emote.GENERIC, 'Where do I find some flour?'],
+            _cook => [
                 Emote.GENERIC,
-                `There is a Mill fairly close, go North and then West. Mill Lane Mill ` +
-                    `is just off the road to Draynor. I usually get my flour from there.`,
+                'There is a Mill fairly close, go North and then West. Mill Lane Mill ' +
+                    'is just off the road to Draynor. I usually get my flour from there.',
             ],
-            cook => [Emote.HAPPY, `Talk to Millie, she'll help, she's a lovely girl and a fine Miller.`],
+            _cook => [Emote.HAPPY, `Talk to Millie, she'll help, she's a lovely girl and a fine Miller.`],
             goto('tag_INGREDIENT_QUESTIONS'),
         ],
-        `How about milk?`,
+        'How about milk?',
         [
-            player => [Emote.GENERIC, `How about milk?`],
-            cook => [Emote.GENERIC, `There is a cattle field on the other side of the river, just across ` + `the road from Groats' Farm.`],
-            cook => [
+            _player => [Emote.GENERIC, 'How about milk?'],
+            _cook => [
+                Emote.GENERIC,
+                'There is a cattle field on the other side of the river, just across ' + `the road from Groats' Farm.`,
+            ],
+            _cook => [
                 Emote.HAPPY,
-                `Talk to Gillie Groats, she look after the Dairy Cows - ` +
+                'Talk to Gillie Groats, she look after the Dairy Cows - ' +
                     `she'll tell you everything you need to know about milking cows!`,
             ],
             goto('tag_INGREDIENT_QUESTIONS'),
         ],
-        `And eggs? Where are they found?`,
+        'And eggs? Where are they found?',
         [
-            player => [Emote.GENERIC, `And eggs? Where are they found?`],
-            cook => [Emote.GENERIC, `I normally get my eggs from the Groats' farm, on the other side of ` + `the river.`],
-            cook => [Emote.GENERIC, `But any chicken should lay eggs.`],
+            _player => [Emote.GENERIC, 'And eggs? Where are they found?'],
+            _cook => [Emote.GENERIC, `I normally get my eggs from the Groats' farm, on the other side of ` + 'the river.'],
+            _cook => [Emote.GENERIC, 'But any chicken should lay eggs.'],
             goto('tag_INGREDIENT_QUESTIONS'),
         ],
-        `Actually, I know where to find this stuff.`,
-        [player => [Emote.GENERIC, `I've got all the information I need. Thanks.`]],
+        'Actually, I know where to find this stuff.',
+        [_player => [Emote.GENERIC, `I've got all the information I need. Thanks.`]],
     ];
 }
 
@@ -98,87 +101,87 @@ const startQuestAction: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'cook' }],
         [
-            cook => [Emote.WORRIED, `What am I to do?`],
-            options => [
+            _cook => [Emote.WORRIED, 'What am I to do?'],
+            _options => [
                 `What's wrong?`,
                 [],
-                `Can you make me a cake?`,
+                'Can you make me a cake?',
                 [
-                    player => [Emote.HAPPY, `You're a cook, why don't you bake me a cake?`],
-                    cook => [Emote.SAD, `*sniff* Don't talk to me about cakes...`],
+                    _player => [Emote.HAPPY, `You're a cook, why don't you bake me a cake?`],
+                    _cook => [Emote.SAD, `*sniff* Don't talk to me about cakes...`],
                 ],
                 `You don't look very happy.`,
                 [
-                    player => [Emote.WORRIED, `You don't look very happy.`],
-                    cook => [
+                    _player => [Emote.WORRIED, `You don't look very happy.`],
+                    _cook => [
                         Emote.SAD,
-                        `No, I'm not. The world is caving in around me - I am overcome by dark feelings ` + `of impending doom.`,
+                        `No, I'm not. The world is caving in around me - I am overcome by dark feelings ` + 'of impending doom.',
                     ],
-                    options => [
+                    _options => [
                         `What's wrong?`,
                         [],
                         `I'd take the rest of the day off if I were you.`,
                         [
-                            player => [Emote.GENERIC, `I'd take the rest of the day off if I were you.`],
-                            cook => [Emote.WORRIED, `No, that's the worst thing I could do. I'd get in terrible trouble.`],
-                            player => [Emote.SKEPTICAL, `Well maybe you need to take a holiday...`],
-                            cook => [Emote.SAD, `That would be nice, but the Duke doesn't allow holidays for core staff.`],
-                            player => [Emote.LAUGH, `Hmm, why not run away to the sea and start a new life as a Pirate?`],
-                            cook => [
+                            _player => [Emote.GENERIC, `I'd take the rest of the day off if I were you.`],
+                            _cook => [Emote.WORRIED, `No, that's the worst thing I could do. I'd get in terrible trouble.`],
+                            _player => [Emote.SKEPTICAL, 'Well maybe you need to take a holiday...'],
+                            _cook => [Emote.SAD, `That would be nice, but the Duke doesn't allow holidays for core staff.`],
+                            _player => [Emote.LAUGH, 'Hmm, why not run away to the sea and start a new life as a Pirate?'],
+                            _cook => [
                                 Emote.SKEPTICAL,
-                                `My wife gets sea sick, and I have an irrational fear of eyepatches. ` + `I don't see it working myself.`,
+                                'My wife gets sea sick, and I have an irrational fear of eyepatches. ' + `I don't see it working myself.`,
                             ],
-                            player => [Emote.WORRIED, `I'm afraid I've run out of ideas.`],
-                            cook => [Emote.SAD, `I know I'm doomed.`],
+                            _player => [Emote.WORRIED, `I'm afraid I've run out of ideas.`],
+                            _cook => [Emote.SAD, `I know I'm doomed.`],
                         ],
                     ],
                 ],
-                `Nice hat!`,
+                'Nice hat!',
                 [
-                    player => [Emote.HAPPY, `Nice hat!`],
-                    cook => [Emote.SKEPTICAL, `Err thank you. It's a pretty ordinary cooks hat really.`],
-                    player => [Emote.HAPPY, `Still, suits you. The trousers are pretty special too.`],
-                    cook => [Emote.SKEPTICAL, `It's all standard cook's issue uniform...`],
-                    player => [
+                    _player => [Emote.HAPPY, 'Nice hat!'],
+                    _cook => [Emote.SKEPTICAL, `Err thank you. It's a pretty ordinary cooks hat really.`],
+                    _player => [Emote.HAPPY, 'Still, suits you. The trousers are pretty special too.'],
+                    _cook => [Emote.SKEPTICAL, `It's all standard cook's issue uniform...`],
+                    _player => [
                         Emote.POMPOUS,
-                        `The whole hat, apron, striped trousers ensemble - it works. It makes you ` + `look like a real cook.`,
+                        'The whole hat, apron, striped trousers ensemble - it works. It makes you ' + 'look like a real cook.',
                     ],
-                    cook => [
+                    _cook => [
                         Emote.ANGRY,
-                        `I am a real cook! I haven't got time to be chatting about Culinary Fashion. ` + `I am in desperate need of help!`,
+                        `I am a real cook! I haven't got time to be chatting about Culinary Fashion. ` + 'I am in desperate need of help!',
                     ],
                 ],
             ],
-            player => [Emote.HAPPY, `What's wrong?`],
-            cook => [
+            _player => [Emote.HAPPY, `What's wrong?`],
+            _cook => [
                 Emote.WORRIED,
                 `Oh dear, oh dear, oh dear, I'm in a terrible terrible ` +
                     ` mess! It's the Duke's birthday today, and I should be making him a lovely big birthday cake.`,
             ],
-            cook => [
+            _cook => [
                 Emote.WORRIED,
                 `I've forgotten to buy the ingredients. I'll never get ` +
                     `them in time now. He'll sack me! What will I do? I have four children and a goat to ` +
-                    `look after. Would you help me? Please?`,
+                    'look after. Would you help me? Please?',
             ],
-            options => [
+            _options => [
                 `I'm always happy to help a cook in distress.`,
                 [
                     execute(() => {
                         player.setQuestProgress('rs:cooks_assistant', 50);
                     }),
-                    player => [Emote.GENERIC, `Yes, I'll help you.`],
-                    cook => [
+                    _player => [Emote.GENERIC, `Yes, I'll help you.`],
+                    _cook => [
                         Emote.HAPPY,
-                        `Oh thank you, thank you. I need milk, an egg and flour. I'd be very grateful ` + `if you can get them for me.`,
+                        `Oh thank you, thank you. I need milk, an egg and flour. I'd be very grateful ` + 'if you can get them for me.',
                     ],
-                    player => [Emote.GENERIC, `So where do I find these ingredients then?`],
+                    _player => [Emote.GENERIC, 'So where do I find these ingredients then?'],
                     dialogueIngredientQuestions(),
                 ],
                 `I can't right now, maybe later.`,
                 [
-                    player => [Emote.GENERIC, `No, I don't feel like it. Maybe later.`],
-                    cook => [Emote.ANGRY, `Fine. I always knew you Adventurer types were callous beasts. ` + `Go on your merry way!`],
+                    _player => [Emote.GENERIC, `No, I don't feel like it. Maybe later.`],
+                    _cook => [Emote.ANGRY, 'Fine. I always knew you Adventurer types were callous beasts. ' + 'Go on your merry way!'],
                 ],
             ],
         ],
@@ -187,14 +190,14 @@ const startQuestAction: npcInteractionActionHandler = details => {
 
 function youStillNeed(quest: PlayerQuest): DialogueTree {
     return [
-        text =>
-            `You still need to get\n` +
-            `${!quest.metadata.givenMilk ? `A bucket of milk. ` : ``}${!quest.metadata.givenFlour ? `A pot of flour. ` : ``}${!quest.metadata.givenEgg ? `An egg.` : ``}`,
-        options => [
+        _text =>
+            'You still need to get\n' +
+            `${!quest.metadata.givenMilk ? 'A bucket of milk. ' : ''}${!quest.metadata.givenFlour ? 'A pot of flour. ' : ''}${!quest.metadata.givenEgg ? 'An egg.' : ''}`,
+        _options => [
             `I'll get right on it.`,
-            [player => [Emote.GENERIC, `I'll get right on it.`]],
-            `Can you remind me how to find these things again?`,
-            [player => [Emote.GENERIC, `So where do I find these ingredients then?`], dialogueIngredientQuestions()],
+            [_player => [Emote.GENERIC, `I'll get right on it.`]],
+            'Can you remind me how to find these things again?',
+            [_player => [Emote.GENERIC, 'So where do I find these ingredients then?'], dialogueIngredientQuestions()],
         ],
     ];
 }
@@ -202,7 +205,7 @@ function youStillNeed(quest: PlayerQuest): DialogueTree {
 const handInIngredientsAction: npcInteractionActionHandler = async details => {
     const { player, npc } = details;
 
-    const dialogueTree: DialogueTree = [cook => [Emote.GENERIC, `How are you getting on with finding the ingredients?`]];
+    const dialogueTree: DialogueTree = [_cook => [Emote.GENERIC, 'How are you getting on with finding the ingredients?']];
 
     const quest = player.getQuest('rs:cooks_assistant');
 
@@ -223,7 +226,7 @@ const handInIngredientsAction: npcInteractionActionHandler = async details => {
         }
 
         dialogueTree.push(
-            player => [Emote.GENERIC, ingredient.text],
+            _player => [Emote.GENERIC, ingredient.text],
             execute(() => {
                 const quest = player.getQuest('rs:cooks_assistant');
 
@@ -250,28 +253,28 @@ const handInIngredientsAction: npcInteractionActionHandler = async details => {
                 return 'tag_SOME_INGREDIENTS';
             }
         }),
-        (subtree, tag_ALL_INGREDIENTS) => [
-            cook => [Emote.HAPPY, `You've brought me everything I need! I am saved! Thank you!`],
-            player => [Emote.WONDERING, `So do I get to go to the Duke's Party?`],
-            cook => [Emote.SAD, `I'm afraid not, only the big cheeses get to dine with the Duke.`],
-            player => [Emote.GENERIC, `Well, maybe one day I'll be important enough to sit on the Duke's table.`],
-            cook => [Emote.SKEPTICAL, `Maybe, but I won't be holding my breath.`],
+        (_subtree, _tag_ALL_INGREDIENTS) => [
+            _cook => [Emote.HAPPY, `You've brought me everything I need! I am saved! Thank you!`],
+            _player => [Emote.WONDERING, `So do I get to go to the Duke's Party?`],
+            _cook => [Emote.SAD, `I'm afraid not, only the big cheeses get to dine with the Duke.`],
+            _player => [Emote.GENERIC, `Well, maybe one day I'll be important enough to sit on the Duke's table.`],
+            _cook => [Emote.SKEPTICAL, `Maybe, but I won't be holding my breath.`],
             execute(() => {
                 questComplete = true;
             }),
         ],
-        (subtree, tag_NO_INGREDIENTS) => [
-            player => [Emote.GENERIC, `I haven't got any of them yet, I'm still looking.`],
-            cook => [
+        (_subtree, _tag_NO_INGREDIENTS) => [
+            _player => [Emote.GENERIC, `I haven't got any of them yet, I'm still looking.`],
+            _cook => [
                 Emote.SAD,
-                `Please get the ingredients quickly. I'm running out of time! ` + `The Duke will throw me into the streets!`,
+                `Please get the ingredients quickly. I'm running out of time! ` + 'The Duke will throw me into the streets!',
             ],
             ...youStillNeed(quest),
         ],
-        (subtree, tag_SOME_INGREDIENTS) => [
-            cook => [
+        (_subtree, _tag_SOME_INGREDIENTS) => [
+            _cook => [
                 Emote.SAD,
-                `Thanks for the ingredients you have got so far, please get the rest quickly. ` +
+                'Thanks for the ingredients you have got so far, please get the rest quickly. ' +
                     `I'm running out of time! The Duke will throw me into the streets!`,
             ],
             ...youStillNeed(quest),

--- a/src/plugins/quests/goblin-diplomacy-tutorial/goblin-diplomacy-quest.plugin.ts
+++ b/src/plugins/quests/goblin-diplomacy-tutorial/goblin-diplomacy-quest.plugin.ts
@@ -48,7 +48,7 @@ export function showTabWidgetHint(
     };
     player.metadata.tabClickEvent = tabClickEvent;
 
-    dialogue([player], [titled => [helpTitle, helpText]], {
+    dialogue([player], [_titled => [helpTitle, helpText]], {
         permanent: true,
     });
 
@@ -111,7 +111,7 @@ export const startTutorial = async (player: Player): Promise<void> => {
     player.inventory.add('rs:coins');
     player.outgoingPackets.sendUpdateAllWidgetItems(widgets.inventory, player.inventory);
 
-    await dialogue([player], [titled => [`Getting Started`, `\nCreate your character!`]], {
+    await dialogue([player], [() => ['Getting Started', '\nCreate your character!']], {
         permanent: true,
     });
 
@@ -133,14 +133,14 @@ export async function spawnGoblinBoi(player: Player, spawnPoint: 'beginning' | '
     if (spawnPoint === 'beginning') {
         //const goblin = await world.spawnNpc('rs:goblin', new Position(3219, 3246), 'SOUTH',
         //    0, player.instance.instanceId);
-        const goblin = await activeWorld.spawnNpc('rs:goblin', new Position(3221, 3257), 'SOUTH', 0, player.instance.instanceId);
+        const goblin = await activeWorld.spawnNpc('rs:goblin', new Position(3221, 3257), 'SOUTH', 0);
 
         goblin.pathfinding.walkTo(new Position(3219, 3246), {
             pathingSearchRadius: 16,
             ignoreDestination: false,
         });
     } else {
-        await activeWorld.spawnNpc('rs:goblin', new Position(3219, 3246), 'SOUTH', 0, player.instance.instanceId);
+        await activeWorld.spawnNpc('rs:goblin', new Position(3219, 3246), 'SOUTH', 0);
     }
 }
 
@@ -160,16 +160,16 @@ export async function tutorialHandler(player: Player): Promise<void> {
     }
 }
 
-function spawnQuestNpcs(player: Player): void {
-    activeWorld.spawnNpc('rs:runescape_guide', new Position(3230, 3238), 'SOUTH', 2, player.instance.instanceId);
-    activeWorld.spawnNpc('rs:melee_combat_tutor', new Position(3219, 3238), 'EAST', 1, player.instance.instanceId);
+function spawnQuestNpcs(): void {
+    activeWorld.spawnNpc('rs:runescape_guide', new Position(3230, 3238), 'SOUTH', 2);
+    activeWorld.spawnNpc('rs:melee_combat_tutor', new Position(3219, 3238), 'EAST', 1);
 }
 
 const tutorialInitAction: playerInitActionHandler = async ({ player }) => {
     if (serverConfig.tutorialEnabled && !player.savedMetadata.tutorialComplete) {
         player.instance = new WorldInstance(v4());
         player.metadata.blockObjectInteractions = true;
-        spawnQuestNpcs(player);
+        spawnQuestNpcs();
         await tutorialHandler(player);
     } else {
         defaultPlayerTabWidgets().forEach((widgetId: number, tabIndex: number) => {
@@ -199,7 +199,7 @@ const createCharacterAction: buttonActionHandler = ({ player }): void => {
 };
 
 const journalHandler: QuestJournalHandler = {
-    0: `stinkyu hoomsn HAHA\n\n\nf1nglewuRt`,
+    0: 'stinkyu hoomsn HAHA\n\n\nf1nglewuRt',
 };
 
 const QUEST_ID = 'tyn:goblin_diplomacy';
@@ -207,7 +207,7 @@ const QUEST_ID = 'tyn:goblin_diplomacy';
 const QUEST = new Quest({
     id: QUEST_ID,
     questTabId: 28,
-    name: `Goblin Diplomacy`,
+    name: 'Goblin Diplomacy',
     points: 1,
     journalHandler,
     onComplete: {

--- a/src/plugins/quests/goblin-diplomacy-tutorial/melee-tutor-dialogue.ts
+++ b/src/plugins/quests/goblin-diplomacy-tutorial/melee-tutor-dialogue.ts
@@ -6,15 +6,15 @@ export const harlanDialogueHandler: QuestDialogueHandler = {
         await dialogue(
             [player, { npc, key: 'harlan' }],
             [
-                harlan => [Emote.GENERIC, `Greetings, adventurer. How can I assist you?`],
-                player => [Emote.WONDERING, `The guide in there said you could unlock my inventory and stuff.`],
-                harlan => [Emote.LAUGH, `I suppose I could, yes. But where's the fun in that?`],
-                player => [Emote.SAD, `I just want to fight something.`],
-                harlan => [
+                _harlan => [Emote.GENERIC, 'Greetings, adventurer. How can I assist you?'],
+                _player => [Emote.WONDERING, 'The guide in there said you could unlock my inventory and stuff.'],
+                _harlan => [Emote.LAUGH, `I suppose I could, yes. But where's the fun in that?`],
+                _player => [Emote.SAD, 'I just want to fight something.'],
+                _harlan => [
                     Emote.GENERIC,
                     `I'm sure you'll get the chance, what with all the recent goblin attacks on this side of the River Lum.`,
                 ],
-                harlan => [Emote.GENERIC, `To that end, let me show you your inventory.`],
+                _harlan => [Emote.GENERIC, 'To that end, let me show you your inventory.'],
                 execute(() => {
                     player.setQuestProgress('tyn:goblin_diplomacy', 55);
                 }),
@@ -22,15 +22,15 @@ export const harlanDialogueHandler: QuestDialogueHandler = {
         );
     },
     55: async (player, npc) => {
-        await dialogue([player, { npc, key: 'harlan' }], [harlan => [Emote.GENERIC, `Speak with me once you've opened your inventory.`]]);
+        await dialogue([player, { npc, key: 'harlan' }], [_harlan => [Emote.GENERIC, `Speak with me once you've opened your inventory.`]]);
     },
     60: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'harlan' }],
             [
-                player => [Emote.SAD, `Doesn't look like I had much on me...`],
-                harlan => [Emote.GENERIC, `I would say the goblins likely ran through your pockets before the Guard hauled you in.`],
-                harlan => [Emote.GENERIC, `Lets check out your hitpoints and make sure you're in proper shape after that.`],
+                _player => [Emote.SAD, `Doesn't look like I had much on me...`],
+                _harlan => [Emote.GENERIC, 'I would say the goblins likely ran through your pockets before the Guard hauled you in.'],
+                _harlan => [Emote.GENERIC, `Lets check out your hitpoints and make sure you're in proper shape after that.`],
                 execute(() => {
                     player.setQuestProgress('tyn:goblin_diplomacy', 65);
                 }),
@@ -41,9 +41,9 @@ export const harlanDialogueHandler: QuestDialogueHandler = {
         await dialogue(
             [player, { npc, key: 'harlan' }],
             [
-                harlan => [
+                _harlan => [
                     Emote.GENERIC,
-                    `Click on your skills tab to view your hitpoints stat. It should be blinking over near your inventory.`,
+                    'Click on your skills tab to view your hitpoints stat. It should be blinking over near your inventory.',
                 ],
             ],
         );
@@ -52,13 +52,13 @@ export const harlanDialogueHandler: QuestDialogueHandler = {
         await dialogue(
             [player, { npc, key: 'harlan' }],
             [
-                harlan => [
+                _harlan => [
                     Emote.GENERIC,
-                    `You appear to be in good shape. Though with a backpack like that, ` +
+                    'You appear to be in good shape. Though with a backpack like that, ' +
                         `I don't think you'll make much headway against those goblins...`,
                 ],
-                harlan => [Emote.GENERIC, `I'll provide you with some starter equipment - but from there, you're on your own.`],
-                harlan => [Emote.GENERIC, `But before I can do that, you'll need to open your Equipment tab.`],
+                _harlan => [Emote.GENERIC, `I'll provide you with some starter equipment - but from there, you're on your own.`],
+                _harlan => [Emote.GENERIC, `But before I can do that, you'll need to open your Equipment tab.`],
                 execute(() => {
                     player.setQuestProgress('tyn:goblin_diplomacy', 75);
                 }),
@@ -66,26 +66,26 @@ export const harlanDialogueHandler: QuestDialogueHandler = {
         );
     },
     75: async (player, npc) => {
-        await dialogue([player, { npc, key: 'harlan' }], [harlan => [Emote.GENERIC, `Speak with me once you've opened your equipment.`]]);
+        await dialogue([player, { npc, key: 'harlan' }], [_harlan => [Emote.GENERIC, `Speak with me once you've opened your equipment.`]]);
     },
     80: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'harlan' }],
             [
-                harlan => [Emote.GENERIC, `Have this training equipment and try it on.`],
+                _harlan => [Emote.GENERIC, 'Have this training equipment and try it on.'],
                 execute(() => {
                     player.inventory.add('rs:training_sword');
                     player.inventory.add('rs:training_shield');
                     player.setQuestProgress('tyn:goblin_diplomacy', 85);
                 }),
-                text => `Harlan hands you a Training sword and shield.`,
+                _text => 'Harlan hands you a Training sword and shield.',
             ],
         );
     },
     85: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'harlan' }],
-            [harlan => [Emote.GENERIC, `Try on the Training sword and shield and we can continue.`]],
+            [_harlan => [Emote.GENERIC, 'Try on the Training sword and shield and we can continue.']],
         );
     },
 };

--- a/src/plugins/quests/goblin-diplomacy-tutorial/runescape-guide-dialogue.ts
+++ b/src/plugins/quests/goblin-diplomacy-tutorial/runescape-guide-dialogue.ts
@@ -9,16 +9,16 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
         await dialogue(
             [player, { npc, key: 'guide' }],
             [
-                guide => [Emote.GENERIC, `Greetings adventurer, welcome to RuneScape.`],
-                player => [Emote.SKEPTICAL, `How did I get here?...`],
-                guide => [Emote.GENERIC, `Seems like a goblin smacked you over the head on your way in. Nasty little things.`],
-                player => [Emote.DROWZY, `I guess that explains the headache.`],
-                guide => [Emote.GENERIC, `I would imagine so. Now, it's my job here is to show new players around.`],
-                options => [
-                    `Go on.`,
+                _guide => [Emote.GENERIC, 'Greetings adventurer, welcome to RuneScape.'],
+                _player => [Emote.SKEPTICAL, 'How did I get here?...'],
+                _guide => [Emote.GENERIC, 'Seems like a goblin smacked you over the head on your way in. Nasty little things.'],
+                _player => [Emote.DROWZY, 'I guess that explains the headache.'],
+                _guide => [Emote.GENERIC, `I would imagine so. Now, it's my job here is to show new players around.`],
+                _options => [
+                    'Go on.',
                     [
-                        player => [Emote.GENERIC, `Carry on then.`],
-                        guide => [
+                        _player => [Emote.GENERIC, 'Carry on then.'],
+                        _guide => [
                             Emote.GENERIC,
                             `We'll start with the Options menu. Click on the blinking spanner icon at the bottom right of your game screen.`,
                         ],
@@ -26,10 +26,10 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
                             player.setQuestProgress('tyn:goblin_diplomacy', 10);
                         }),
                     ],
-                    `I know how the game works already.`,
+                    'I know how the game works already.',
                     [
-                        player => [Emote.HAPPY, `This isn't my first time here, I'm good.`],
-                        guide => [Emote.HAPPY, `Oh good, I won't tell you what you already know then.`],
+                        _player => [Emote.HAPPY, `This isn't my first time here, I'm good.`],
+                        _guide => [Emote.HAPPY, `Oh good, I won't tell you what you already know then.`],
                         execute(() => {
                             player.savedMetadata.tutorialComplete = true;
                             player.setQuestProgress('tyn:goblin_diplomacy', 'complete');
@@ -50,14 +50,14 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
     10: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
-            [guide => [Emote.GENERIC, 'Please click on the blinking spanner icon, then we can continue.']],
+            [_guide => [Emote.GENERIC, 'Please click on the blinking spanner icon, then we can continue.']],
         );
     },
     15: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
             [
-                guide => [
+                _guide => [
                     Emote.HAPPY,
                     `Next we'll move on to the more social side of things. Click on the blinking icon to learn about the Friends List.`,
                 ],
@@ -70,31 +70,31 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
     20: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
-            [guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
+            [_guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
         );
     },
     25: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
-            [guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
+            [_guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
         );
     },
     30: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
-            [guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
+            [_guide => [Emote.GENERIC, `Please return to me once you've gone through all three social tabs.`]],
         );
     },
     35: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
             [
-                player => [Emote.HAPPY, `I've gone through the Friends List and everything. When do I get to kill things?`],
-                guide => [Emote.LAUGH, `All in good time, ${player.username}. We've a little more to discuss yet - like music!`],
-                player => [Emote.SKEPTICAL, `Music? Doesn't everyone turn that off?`],
-                guide => [Emote.SAD, `Some people find it nostalgic.`],
-                player => [Emote.SAD, `Sorry, go on...`],
-                guide => [Emote.GENERIC, `Yes... As I was saying... Music can be accessed from the music tab.`],
+                _player => [Emote.HAPPY, `I've gone through the Friends List and everything. When do I get to kill things?`],
+                _guide => [Emote.LAUGH, `All in good time, ${player.username}. We've a little more to discuss yet - like music!`],
+                _player => [Emote.SKEPTICAL, `Music? Doesn't everyone turn that off?`],
+                _guide => [Emote.SAD, 'Some people find it nostalgic.'],
+                _player => [Emote.SAD, 'Sorry, go on...'],
+                _guide => [Emote.GENERIC, 'Yes... As I was saying... Music can be accessed from the music tab.'],
                 execute(() => {
                     player.setQuestProgress('tyn:goblin_diplomacy', 40);
                 }),
@@ -105,13 +105,13 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
         await dialogue(
             [player, { npc, key: 'guide' }],
             [
-                player => [Emote.HAPPY, `That music tab is pretty nostalgic, I'll give ya that.`],
-                guide => [Emote.LAUGH, `Isn't it? Sometimes I can hear Harmony in my sleep.`],
-                player => [Emote.WONDERING, `So what's next?`],
-                guide => [Emote.GENERIC, `Next you'll be moving on to my friend Harlan, to learn about your inventory and skills.`],
-                player => [Emote.HAPPY, `So I finally get to kill something?`],
-                guide => [Emote.SAD, `That's all you adventurers ever want to do...`],
-                guide => [
+                _player => [Emote.HAPPY, `That music tab is pretty nostalgic, I'll give ya that.`],
+                _guide => [Emote.LAUGH, `Isn't it? Sometimes I can hear Harmony in my sleep.`],
+                _player => [Emote.WONDERING, `So what's next?`],
+                _guide => [Emote.GENERIC, `Next you'll be moving on to my friend Harlan, to learn about your inventory and skills.`],
+                _player => [Emote.HAPPY, 'So I finally get to kill something?'],
+                _guide => [Emote.SAD, `That's all you adventurers ever want to do...`],
+                _guide => [
                     Emote.GENERIC,
                     `Oh well. Head on over to Harlan, the melee combat tutor, and I'm sure he'll show you how to kill something.`,
                 ],
@@ -124,7 +124,7 @@ export const runescapeGuideDialogueHandler: QuestDialogueHandler = {
     50: async (player, npc) => {
         await dialogue(
             [player, { npc, key: 'guide' }],
-            [guide => [Emote.GENERIC, `Please speak to my friend Harlan, the melee combat tutor, to continue.`]],
+            [_guide => [Emote.GENERIC, 'Please speak to my friend Harlan, the melee combat tutor, to continue.']],
         );
     },
 };

--- a/src/plugins/quests/goblin-diplomacy-tutorial/stage-handler.ts
+++ b/src/plugins/quests/goblin-diplomacy-tutorial/stage-handler.ts
@@ -24,7 +24,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
     5: async player => {
         npcHint(player, 'rs:runescape_guide');
 
-        await dialogue([player], [titled => [`Getting Started`, `\nWelcome to RuneScape!\nSpeak with the Guide to begin your journey.`]], {
+        await dialogue([player], [_titled => ['Getting Started', '\nWelcome to RuneScape!\nSpeak with the Guide to begin your journey.']], {
             permanent: true,
         });
     },
@@ -34,9 +34,9 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['settings'],
             1,
             15,
-            `Game Options`,
-            `The Options menu can be used to modify various game settings.\n` +
-                `Click the blinking icon to open the Options menu.\n\n` +
+            'Game Options',
+            'The Options menu can be used to modify various game settings.\n' +
+                'Click the blinking icon to open the Options menu.\n\n' +
                 `When you're finished, speak with the Guide to continue.`,
         );
     },
@@ -45,12 +45,12 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
 
         unlockAvailableTabs(player, 1);
 
-        dialogue([player], [titled => [`Getting Started`, `\nSpeak with the Guide to continue.`]], {
+        dialogue([player], [_titled => ['Getting Started', '\nSpeak with the Guide to continue.']], {
             permanent: true,
         });
     },
     20: player => {
-        showTabWidgetHint(player, tabIndex['friends'], 2, 25, `Friends List`, `\nKeep track of your friends via the Friends List.`);
+        showTabWidgetHint(player, tabIndex['friends'], 2, 25, 'Friends List', '\nKeep track of your friends via the Friends List.');
     },
     25: player => {
         showTabWidgetHint(
@@ -58,9 +58,9 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['ignores'],
             3,
             30,
-            `Ignore List`,
-            `\nThe Ignore List allows you to block messages from other users.\n` +
-                `Check it out by clicking the blinking icon at the bottom right.`,
+            'Ignore List',
+            '\nThe Ignore List allows you to block messages from other users.\n' +
+                'Check it out by clicking the blinking icon at the bottom right.',
         );
     },
     30: player => {
@@ -69,9 +69,9 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['emotes'],
             4,
             35,
-            `Emotes`,
-            `Perform emotes for other players via the Emotes tab.\n\n` +
-                `Click on the blinking Emotes tab to see the list of emotes you can perform, then speak with the Guide to continue.`,
+            'Emotes',
+            'Perform emotes for other players via the Emotes tab.\n\n' +
+                'Click on the blinking Emotes tab to see the list of emotes you can perform, then speak with the Guide to continue.',
         );
     },
     35: player => {
@@ -79,7 +79,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
 
         unlockAvailableTabs(player, 4);
 
-        dialogue([player], [titled => [`Continue`, `\nSpeak with the Guide to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nSpeak with the Guide to continue.']], {
             permanent: true,
         });
     },
@@ -89,15 +89,15 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['music'],
             5,
             45,
-            `Music`,
-            `Check out the music tab to view and play all of your favorite RuneScape tracks!\n` + `Once you've unlocked them, of course.`,
+            'Music',
+            'Check out the music tab to view and play all of your favorite RuneScape tracks!\n' + `Once you've unlocked them, of course.`,
         );
     },
     45: player => {
         npcHint(player, 'rs:runescape_guide');
         unlockAvailableTabs(player, 5);
 
-        dialogue([player], [titled => [`Continue`, `\nSpeak with the Guide to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nSpeak with the Guide to continue.']], {
             permanent: true,
         });
     },
@@ -106,7 +106,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
         npcHint(player, 'rs:melee_combat_tutor');
         unlockAvailableTabs(player, 5);
 
-        dialogue([player], [titled => [`Continue`, `\nSpeak with the Melee Combat Tutor to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nSpeak with the Melee Combat Tutor to continue.']], {
             permanent: true,
         });
     },
@@ -116,16 +116,16 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['inventory'],
             6,
             60,
-            `Inventory`,
+            'Inventory',
             `Your inventory contains any items held on your person that aren't equipped. ` +
-                `Click the blinking backpack icon to open your inventory.`,
+                'Click the blinking backpack icon to open your inventory.',
         );
     },
     60: player => {
         npcHint(player, 'rs:melee_combat_tutor');
         unlockAvailableTabs(player, 6);
 
-        dialogue([player], [titled => [`Continue`, `\nTalk-to the Melee Combat Tutor to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nTalk-to the Melee Combat Tutor to continue.']], {
             permanent: true,
         });
     },
@@ -135,7 +135,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['skills'],
             7,
             70,
-            `Skills`,
+            'Skills',
             `You can see your character's skill levels on the Skills tab, including your current number of hitpoints. ` +
                 `If your hitpoints ever reach zero, you'll die - so be careful!`,
         );
@@ -144,7 +144,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
         npcHint(player, 'rs:melee_combat_tutor');
         unlockAvailableTabs(player, 7);
 
-        dialogue([player], [titled => [`Continue`, `\nTalk-to the Melee Combat Tutor to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nTalk-to the Melee Combat Tutor to continue.']], {
             permanent: true,
         });
     },
@@ -154,23 +154,23 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
             tabIndex['equipment'],
             8,
             80,
-            `Equipment`,
-            `The equipment tab contains details on everything you have equipped, as well as any stat ` +
-                `bonuses received from your equipment.`,
+            'Equipment',
+            'The equipment tab contains details on everything you have equipped, as well as any stat ' +
+                'bonuses received from your equipment.',
         );
     },
     80: player => {
         npcHint(player, 'rs:melee_combat_tutor');
         unlockAvailableTabs(player, 8);
 
-        dialogue([player], [titled => [`Continue`, `\nTalk-to the Melee Combat Tutor to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nTalk-to the Melee Combat Tutor to continue.']], {
             permanent: true,
         });
     },
     85: player => {
         unlockAvailableTabs(player, 8);
 
-        dialogue([player], [titled => [`Continue`, `\nEquip the Training sword and shield.`]], {
+        dialogue([player], [_titled => ['Continue', '\nEquip the Training sword and shield.']], {
             permanent: true,
         });
     },
@@ -178,7 +178,7 @@ export const goblinDiplomacyStageHandler: QuestStageHandler = {
         npcHint(player, 'rs:melee_combat_tutor');
         unlockAvailableTabs(player, 8);
 
-        dialogue([player], [titled => [`Continue`, `\nTalk-to the Melee Combat Tutor to continue.`]], {
+        dialogue([player], [_titled => ['Continue', '\nTalk-to the Melee Combat Tutor to continue.']], {
             permanent: true,
         });
 

--- a/src/plugins/quests/quest-journal.plugin.ts
+++ b/src/plugins/quests/quest-journal.plugin.ts
@@ -21,7 +21,7 @@ export const handler: buttonActionHandler = async ({ player, buttonId }) => {
     const journalHandler = quest.journalHandler[playerStage];
     if (journalHandler === undefined) {
         const questJournalStages = Object.keys(quest.journalHandler);
-        let journalEntry;
+        let _journalEntry;
         for (const stage of questJournalStages) {
             const stageNum = parseInt(stage, 10);
             if (isNaN(stageNum) || playerStage === 'complete') {
@@ -29,7 +29,7 @@ export const handler: buttonActionHandler = async ({ player, buttonId }) => {
             }
 
             if (stageNum <= playerStage) {
-                journalEntry = stage;
+                _journalEntry = stage;
             } else {
                 break;
             }

--- a/src/plugins/quests/witchs-potion-quest.plugin.ts
+++ b/src/plugins/quests/witchs-potion-quest.plugin.ts
@@ -25,18 +25,18 @@ const journalHandler: QuestJournalHandler = {
             },
             {
                 itemId: itemIds.witchesPotion.burntMeat,
-                haveText: `<str><col=000000>I have a piece of burnt meat with me,</str>`,
+                haveText: '<str><col=000000>I have a piece of burnt meat with me,</str>',
                 dontHaveText: `<col=800000>A piece of burnt meat<col=000080>, I could thoroughly cook a piece of
         <col=000080>raw beef.`,
             },
             {
                 itemId: itemIds.witchesPotion.onion,
-                haveText: `<str><col=000000>I have an onion with me,</str>`,
-                dontHaveText: `<col=800000>An onion<col=000080>, I could probably find one at a farm.`,
+                haveText: '<str><col=000000>I have an onion with me,</str>',
+                dontHaveText: '<col=800000>An onion<col=000080>, I could probably find one at a farm.',
             },
             {
                 itemId: itemIds.witchesPotion.eyeOfNewt,
-                haveText: `<str><col=000000>I have an eye of newt with me,</str>`,
+                haveText: '<str><col=000000>I have an eye of newt with me,</str>',
                 dontHaveText: `<col=800000>An eye of newt<col=000080>, maybe the <col=800000>Magic shop<col=000080> in <col=800000>Port Sarim<col=000080> would
         <col=000080>sell me this?`,
             },
@@ -44,7 +44,7 @@ const journalHandler: QuestJournalHandler = {
 
         let ingredientsObtained = 0;
         for (const ingredient of questLogIngredientData) {
-            questLog += `\n`;
+            questLog += '\n';
             if (player.hasItemInInventory(ingredient.itemId)) {
                 questLog += ingredient.haveText;
                 ingredientsObtained++;
@@ -54,7 +54,7 @@ const journalHandler: QuestJournalHandler = {
         }
 
         if (ingredientsObtained === 4) {
-            questLog += `\n<col=000080>I should bring these ingredients to <col=800000>Hetty<col=000080>.`;
+            questLog += '\n<col=000080>I should bring these ingredients to <col=800000>Hetty<col=000080>.';
         }
 
         return questLog;
@@ -76,7 +76,7 @@ const drinkThePotionDialogue: npcInteractionActionHandler = details => {
     player.face(npc);
     dialogue(
         [player, { npc, key: 'hetty' }],
-        [hetty => [Emote.ANGRY, `Well are you going to drink the potion or not?`], player => [Emote.GENERIC, `Yes, I will.`]],
+        [_hetty => [Emote.ANGRY, 'Well are you going to drink the potion or not?'], _player => [Emote.GENERIC, 'Yes, I will.']],
     );
 };
 
@@ -88,7 +88,7 @@ const drinkFromCauldron: objectInteractionActionHandler = async details => {
     await dialogue(
         [player],
         [
-            text => `You drink from the cauldron. It tastes horrible!\nYou feel yourself imbued with power.`,
+            () => 'You drink from the cauldron. It tastes horrible!\nYou feel yourself imbued with power.',
             execute(() => {
                 questComplete = true;
             }),
@@ -96,14 +96,14 @@ const drinkFromCauldron: objectInteractionActionHandler = async details => {
     );
 
     if (questComplete) {
-        player.setQuestProgress('rs:witchs_potion', `complete`);
+        player.setQuestProgress('rs:witchs_potion', 'complete');
     }
 };
 
 const attemptToDrinkBeforeAllowed: objectInteractionActionHandler = async details => {
     const { player, object } = details;
     player.face(new Position(object.x, object.y));
-    await dialogue([player], [player => [Emote.GENERIC, `As nice as that looks I think I'll give it a miss for now.`]]);
+    await dialogue([player], [() => [Emote.GENERIC, `As nice as that looks I think I'll give it a miss for now.`]]);
 };
 
 const dialogueIngredientQuestions: npcInteractionActionHandler = details => {
@@ -122,22 +122,22 @@ const dialogueIngredientQuestions: npcInteractionActionHandler = details => {
         },
         {
             itemId: itemIds.witchesPotion.burntMeat,
-            haveText: `I have the burnt meat, `,
+            haveText: 'I have the burnt meat, ',
             dontHaveText: `I don't have any burnt meat, `,
         },
         {
             itemId: itemIds.witchesPotion.onion,
-            haveText: `I have an onion, and `,
+            haveText: 'I have an onion, and ',
             dontHaveText: `I don't have an onion, and `,
         },
         {
             itemId: itemIds.witchesPotion.eyeOfNewt,
-            haveText: `I have the eye of newt, yum!`,
+            haveText: 'I have the eye of newt, yum!',
             dontHaveText: `I don't have an eye of newt.`,
         },
     ];
 
-    let requirementsDialogue = ``;
+    let requirementsDialogue = '';
     for (const ingredient of ingredients) {
         if (player.hasItemInInventory(ingredient.itemId)) {
             requirementsDialogue += ingredient.haveText;
@@ -159,36 +159,36 @@ const dialogueIngredientQuestions: npcInteractionActionHandler = details => {
                     return 'tag_SOME_INGREDIENTS';
                 }
             }),
-            (subtree, tag_ALL_INGREDIENTS) => [
-                hetty => [Emote.HAPPY, `So have you found the things for the potion?`],
-                player => [Emote.HAPPY, `Yes I have everything!`],
-                hetty => [Emote.HAPPY, `Excellent, can I have them then?`],
-                (text, tag_has_ingredients) =>
-                    `You pass the ingredients to Hetty and she puts them all into her cauldron. Hetty closes her eyes and begins to chant. The cauldron bubbles mysteriously.`,
-                player => [Emote.GENERIC, `Well, is it ready?`],
+            (_subtree, _tag_ALL_INGREDIENTS) => [
+                _hetty => [Emote.HAPPY, 'So have you found the things for the potion?'],
+                _player => [Emote.HAPPY, 'Yes I have everything!'],
+                _hetty => [Emote.HAPPY, 'Excellent, can I have them then?'],
+                (_text, _tag_has_ingredients) =>
+                    'You pass the ingredients to Hetty and she puts them all into her cauldron. Hetty closes her eyes and begins to chant. The cauldron bubbles mysteriously.',
+                _player => [Emote.GENERIC, 'Well, is it ready?'],
                 execute(() => {
                     player.removeFirstItem(itemIds.witchesPotion.ratsTail);
                     player.removeFirstItem(itemIds.witchesPotion.onion);
                     player.removeFirstItem(itemIds.witchesPotion.burntMeat);
                     player.removeFirstItem(itemIds.witchesPotion.eyeOfNewt);
-                    player.setQuestProgress(`rs:witchs_potion`, 75);
+                    player.setQuestProgress('rs:witchs_potion', 75);
                 }),
-                hetty => [Emote.HAPPY, `Ok, now drink from the cauldron.`],
+                _hetty => [Emote.HAPPY, 'Ok, now drink from the cauldron.'],
             ],
-            (subtree, tag_NO_INGREDIENTS) => [
-                player => [Emote.HAPPY, `I've been looking for those ingredients.`],
-                hetty => [Emote.HAPPY, `So what have you found so far?`],
-                player => [Emote.GENERIC, `I'm afraid I don't have any of them yet.`],
-                hetty => [
+            (_subtree, _tag_NO_INGREDIENTS) => [
+                _player => [Emote.HAPPY, `I've been looking for those ingredients.`],
+                _hetty => [Emote.HAPPY, 'So what have you found so far?'],
+                _player => [Emote.GENERIC, `I'm afraid I don't have any of them yet.`],
+                _hetty => [
                     Emote.SAD,
                     `Well I can't make the potion without them! Remember... You need an eye of newt, a rat's tail, an onion, and a piece of burnt meat. Off you go dear!`,
                 ],
             ],
-            (subtree, tag_SOME_INGREDIENTS) => [
-                player => [Emote.HAPPY, `I've been looking for those ingredients.`],
-                hetty => [Emote.HAPPY, `So what have you found so far?`],
-                player => [Emote.GENERIC, requirementsDialogue],
-                hetty => [Emote.GENERIC, `Great, but I'll need the other ingredients as well.`],
+            (_subtree, _tag_SOME_INGREDIENTS) => [
+                _player => [Emote.HAPPY, `I've been looking for those ingredients.`],
+                _hetty => [Emote.HAPPY, 'So what have you found so far?'],
+                _player => [Emote.GENERIC, requirementsDialogue],
+                _hetty => [Emote.GENERIC, `Great, but I'll need the other ingredients as well.`],
             ],
         ],
     );
@@ -201,9 +201,9 @@ const afterQuestDialogue: npcInteractionActionHandler = details => {
     dialogue(
         [player, { npc, key: 'hetty' }],
         [
-            hetty => [Emote.HAPPY, `How's your magic coming along?`],
-            player => [Emote.HAPPY, `I'm practicing and slowly getting better.`],
-            hetty => [Emote.HAPPY, `Good, good.`],
+            _hetty => [Emote.HAPPY, `How's your magic coming along?`],
+            _player => [Emote.HAPPY, `I'm practicing and slowly getting better.`],
+            _hetty => [Emote.HAPPY, 'Good, good.'],
         ],
     );
 };
@@ -216,70 +216,70 @@ const startQuestAction: npcInteractionActionHandler = async details => {
     await dialogue(
         [player, { npc, key: 'hetty' }],
         [
-            hetty => [Emote.WONDERING, 'What could you want with an old woman like me?'],
-            options => [
-                `I am in search of a quest.`,
+            _hetty => [Emote.WONDERING, 'What could you want with an old woman like me?'],
+            _options => [
+                'I am in search of a quest.',
                 [
-                    (player, tag_search_of_quest) => [Emote.GENERIC, `I am in search of a quest.`],
-                    hetty => [Emote.HAPPY, `Hmmm... Maybe I can think of something for you.`],
-                    hetty => [Emote.HAPPY, `Would you like to become more proficient in the dark arts?`],
+                    (_player, _tag_search_of_quest) => [Emote.GENERIC, 'I am in search of a quest.'],
+                    _hetty => [Emote.HAPPY, 'Hmmm... Maybe I can think of something for you.'],
+                    _hetty => [Emote.HAPPY, 'Would you like to become more proficient in the dark arts?'],
 
-                    options => [
-                        `Yes, help me become one with my darker side.`,
-                        [player => [Emote.HAPPY, `Yes, help me become one with my darker side.`], goto(`tag_darker_side`)],
-                        `No, I have my principles and honour.`,
+                    _options => [
+                        'Yes, help me become one with my darker side.',
+                        [_player => [Emote.HAPPY, 'Yes, help me become one with my darker side.'], goto('tag_darker_side')],
+                        'No, I have my principles and honour.',
                         [
-                            player => [Emote.GENERIC, `No, I have my principles and honour.`],
-                            hetty => [Emote.SAD, `Suit yourself, but you're missing out.`],
+                            _player => [Emote.GENERIC, 'No, I have my principles and honour.'],
+                            _hetty => [Emote.SAD, `Suit yourself, but you're missing out.`],
                         ],
-                        `What, you mean improve my magic?`,
+                        'What, you mean improve my magic?',
                         [
-                            player => [Emote.SAD, 'What, you mean improve my magic?'],
-                            text => `The witch sighs.`,
-                            hetty => [Emote.GENERIC, 'Yes, improve your magic...'],
-                            hetty => [Emote.SAD, 'Do you have no sense of drama?'],
-                            options => [
+                            _player => [Emote.SAD, 'What, you mean improve my magic?'],
+                            _text => 'The witch sighs.',
+                            _hetty => [Emote.GENERIC, 'Yes, improve your magic...'],
+                            _hetty => [Emote.SAD, 'Do you have no sense of drama?'],
+                            _options => [
                                 `Yes, I'd like to improve my magic.`,
                                 [
-                                    player => [Emote.GENERIC, `Yes, I'd like to improve my magic.`],
-                                    (hetty, tag_darker_side) => [
+                                    _player => [Emote.GENERIC, `Yes, I'd like to improve my magic.`],
+                                    (_hetty, _tag_darker_side) => [
                                         Emote.HAPPY,
                                         `Okay, I'm going to make a potion to help bring out your darker self.`,
                                     ],
-                                    hetty => [Emote.GENERIC, `You will need certain ingredients.`],
-                                    player => [Emote.GENERIC, `What do I need?`],
+                                    _hetty => [Emote.GENERIC, 'You will need certain ingredients.'],
+                                    _player => [Emote.GENERIC, 'What do I need?'],
                                     execute(() => {
                                         beginQuest = true;
                                     }),
-                                    hetty => [
+                                    _hetty => [
                                         Emote.WONDERING,
                                         `You need an eye of newt, a rat's tail, an onion... Oh and a piece of burnt meat.`,
                                     ],
-                                    player => [Emote.HAPPY, `Great, I'll go and get them.`],
+                                    _player => [Emote.HAPPY, `Great, I'll go and get them.`],
                                 ],
                                 `No, I'm not interested.`,
                                 [
-                                    player => [Emote.SAD, `No, I'm not interested.`],
-                                    hetty => [Emote.SAD, `Many aren't to start off with.`],
-                                    text => `The witch smiles mysteriously.`,
-                                    hetty => [Emote.GENERIC, `But I think you'll be drawn back to this place.`],
+                                    _player => [Emote.SAD, `No, I'm not interested.`],
+                                    _hetty => [Emote.SAD, `Many aren't to start off with.`],
+                                    _text => 'The witch smiles mysteriously.',
+                                    _hetty => [Emote.GENERIC, `But I think you'll be drawn back to this place.`],
                                 ],
-                                `Show me the mysteries of the dark arts...`,
-                                [player => [Emote.GENERIC, `Show me the mysteries of the dark arts...`], goto(`tag_darker_side`)],
+                                'Show me the mysteries of the dark arts...',
+                                [_player => [Emote.GENERIC, 'Show me the mysteries of the dark arts...'], goto('tag_darker_side')],
                             ],
                         ],
                     ],
                 ],
                 `I've heard that you are a witch.`,
                 [
-                    player => [Emote.HAPPY, `I've heard that you are a witch.`],
-                    hetty => [Emote.HAPPY, `Yes it does seem to be getting fairly common knowledge.`],
-                    hetty => [Emote.WORRIED, `I fear I may get a visit from the witch hunters of Falador before long.`],
-                    options => [
-                        `I am in search of a quest.`,
+                    _player => [Emote.HAPPY, `I've heard that you are a witch.`],
+                    _hetty => [Emote.HAPPY, 'Yes it does seem to be getting fairly common knowledge.'],
+                    _hetty => [Emote.WORRIED, 'I fear I may get a visit from the witch hunters of Falador before long.'],
+                    _options => [
+                        'I am in search of a quest.',
                         [goto('tag_search_of_quest')],
-                        `Goodbye.`,
-                        [player => [Emote.VERY_SAD, `Goodbye.`]],
+                        'Goodbye.',
+                        [_player => [Emote.VERY_SAD, 'Goodbye.']],
                     ],
                 ],
             ],

--- a/src/plugins/skills/construction/house.ts
+++ b/src/plugins/skills/construction/house.ts
@@ -65,7 +65,7 @@ export const openHouse = (player: Player): void => {
         }
     }
 
-    player.sendMessage(`Welcome home.`);
+    player.sendMessage('Welcome home.');
 };
 
 export class House {

--- a/src/plugins/skills/construction/index.ts
+++ b/src/plugins/skills/construction/index.ts
@@ -30,7 +30,7 @@ export default {
             type: 'player_command',
             commands: ['savepoh', 'savehouse'],
             handler: ({ player }: PlayerCommandAction): void => {
-                player.sendMessage(`Saving house data...`);
+                player.sendMessage('Saving house data...');
                 saveHouse(player);
             },
         },

--- a/src/plugins/skills/construction/room-builder.ts
+++ b/src/plugins/skills/construction/room-builder.ts
@@ -18,26 +18,26 @@ const newRoomOriention = (player: Player): number => {
     const playerLocalX = player.position.localX;
     const playerLocalY = player.position.localY;
 
-    let deltaX = 0;
-    let deltaY = 0;
+    let _deltaX = 0;
+    let _deltaY = 0;
 
     let orientation = 0;
 
     if (playerLocalX === 7) {
         // build east
-        deltaX = 1;
+        _deltaX = 1;
         orientation = 1;
     } else if (playerLocalX === 0) {
         // build west
-        deltaX = -1;
+        _deltaX = -1;
         orientation = 3;
     } else if (playerLocalY === 7) {
         // build north
-        deltaY = 1;
+        _deltaY = 1;
         orientation = 0;
     } else if (playerLocalY === 0) {
         // build south
-        deltaY = -1;
+        _deltaY = -1;
         orientation = 2;
     }
 
@@ -80,7 +80,7 @@ export const canBuildNewRoom = (player: Player): Coords | null => {
     }
 
     if (buildX === currentRoom.x && buildY === currentRoom.y) {
-        player.sendMessage(`You can not build there.`);
+        player.sendMessage('You can not build there.');
         return null;
     }
 
@@ -131,7 +131,7 @@ export const roomBuilderWidgetHandler: buttonActionHandler = async ({ player, bu
     await dialogue(
         [player],
         [
-            (options, tag_Home) => [
+            (_options, _tag_Home) => [
                 'Rotate Counter-Clockwise',
                 [
                     execute(() => {

--- a/src/plugins/skills/crafting/sheep-plugin.plugin.ts
+++ b/src/plugins/skills/crafting/sheep-plugin.plugin.ts
@@ -3,16 +3,18 @@ import type { npcInitActionHandler } from '@engine/action/pipe/npc-init.action';
 import { animationIds } from '@engine/world/config/animation-ids';
 import { itemIds } from '@engine/world/config/item-ids';
 import { soundIds } from '@engine/world/config/sound-ids';
+import { World } from '@engine/world/world';
 
 const initAction: npcInitActionHandler = ({ npc }) => {
-    // this used to use `setInterval` but will need rewriting to be synced with ticks
-    // see https://github.com/runejs/server/issues/417
-    // setInterval(() => {
-    //     if(Math.random() >= 0.66) {
-    //         npc.say(`Baa!`);
-    //         npc.playSound(soundIds.sheepBaa, 4);
-    //     }
-    // }, (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH);
+    setInterval(
+        () => {
+            if (Math.random() >= 0.66) {
+                npc.say('Baa!');
+                npc.playSound(soundIds.sheepBaa, 4);
+            }
+        },
+        (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH,
+    );
 };
 
 export const shearAction: itemOnNpcActionHandler = ({ player, npc }) => {
@@ -22,26 +24,26 @@ export const shearAction: itemOnNpcActionHandler = ({ player, npc }) => {
     // set to face position, so it does not look weird when the player walk away
     npc.face(player.position);
 
-    // this used to use `setInterval` but will need rewriting to be synced with ticks
-    // see https://github.com/runejs/server/issues/417
-    player.sendMessage('[debug] see issue #417');
-    // setTimeout(() => {
-    //     if(Math.random() >= 0.66) {
-    //         player.sendMessage('The sheep manages to get away from you!');
-    //         npc.forceMovement(player.faceDirection, 5);
-    //     } else {
-    //         player.sendMessage('You get some wool.');
-    //         player.giveItem(itemIds.wool);
-    //         npc.say('Baa!');
-    //         npc.playSound(soundIds.sheepBaa, 4);
-    //         npc.transformInto('rs:naked_sheep');
+    setTimeout(() => {
+        if (Math.random() >= 0.66) {
+            player.sendMessage('The sheep manages to get away from you!');
+            npc.forceMovement(player.faceDirection, 5);
+        } else {
+            player.sendMessage('You get some wool.');
+            player.giveItem(itemIds.wool);
+            npc.say('Baa!');
+            npc.playSound(soundIds.sheepBaa, 4);
+            npc.transformInto('rs:naked_sheep');
 
-    //         setTimeout(() => {
-    //             npc.transformInto('rs:sheep');
-    //         }, (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH);
-    //     }
-    //     player.busy = false;
-    // }, World.TICK_LENGTH);
+            setTimeout(
+                () => {
+                    npc.transformInto('rs:sheep');
+                },
+                (Math.floor(Math.random() * 20) + 10) * World.TICK_LENGTH,
+            );
+        }
+        player.busy = false;
+    }, World.TICK_LENGTH);
 };
 
 export default {

--- a/src/plugins/skills/firemaking/light-fire.ts
+++ b/src/plugins/skills/firemaking/light-fire.ts
@@ -68,7 +68,7 @@ export const lightFire = (player: Player, position: Position, worldItemLog: Worl
         }
     }
 
-    player.instance.spawnTemporaryGameObject(fireObject, position, fireDurationTicks()).then(() => {
+    player.instance.spawnTemporaryGameObject(fireObject, fireDurationTicks()).then(() => {
         player.instance.spawnWorldItem({ itemId: itemIds.ashes, amount: 1 }, position, { expires: 300 });
     });
 

--- a/src/plugins/skills/runecrafting/runecrafting-altar.plugin.ts
+++ b/src/plugins/skills/runecrafting/runecrafting-altar.plugin.ts
@@ -59,7 +59,7 @@ function finishEnterAltar(player: Player, item: Item, altar: RunecraftingAltar):
     }
 
     player.sendMessage(`You hold the ${talisman.name} towards the mysterious ruins.`);
-    player.sendMessage(`You feel a powerful force take hold of you..`);
+    player.sendMessage('You feel a powerful force take hold of you..');
     player.teleport(altar.entrance);
 }
 

--- a/src/plugins/skills/runecrafting/runecrafting-crafting.plugin.ts
+++ b/src/plugins/skills/runecrafting/runecrafting-crafting.plugin.ts
@@ -60,7 +60,7 @@ const craftRune: objectInteractionActionHandler = (details: ObjectInteractionAct
         return;
     }
 
-    player.sendMessage(`You do not have any rune essence to bind.`);
+    player.sendMessage('You do not have any rune essence to bind.');
 };
 
 function getCombinationRuneByAltar(itemId: number, objectId: number): RunecraftingCombinationRune | undefined {
@@ -132,7 +132,7 @@ const craftCombinationRune: itemOnObjectActionHandler = (details: ItemOnObjectAc
         return;
     }
     //
-    player.sendMessage(`You do not have any pure essence to bind.`);
+    player.sendMessage('You do not have any pure essence to bind.');
 };
 
 export default {

--- a/src/plugins/skills/smithing/forging.plugin.ts
+++ b/src/plugins/skills/smithing/forging.plugin.ts
@@ -123,7 +123,7 @@ const openForgingInterface: itemOnObjectActionHandler = details => {
 
     // The player does not have a hammer.
     if (!player.inventory.has(itemIds.hammer)) {
-        player.sendMessage(`You need a hammer to work the metal with.`, true);
+        player.sendMessage('You need a hammer to work the metal with.', true);
         return;
     }
 

--- a/src/server/game/game-server-connection.ts
+++ b/src/server/game/game-server-connection.ts
@@ -18,7 +18,7 @@ export class GameServerConnection {
     public decodeMessage(buffer?: ByteBuffer): void | Promise<void> {
         if (!this.activeBuffer) {
             if (!buffer) {
-                logger.error(`No buffer provided to decodeMessage.`);
+                logger.error('No buffer provided to decodeMessage.');
                 return;
             } else {
                 this.activeBuffer = buffer;
@@ -109,7 +109,7 @@ export class GameServerConnection {
     }
 
     public connectionDestroyed(): void {
-        logger.info(`Connection destroyed.`);
+        logger.info('Connection destroyed.');
         this.player?.logout();
     }
 

--- a/src/server/gateway/gateway-server.ts
+++ b/src/server/gateway/gateway-server.ts
@@ -47,10 +47,10 @@ export class GatewayServer extends SocketServer {
             });
             this.updateServerSocket.on('data', data => this.clientSocket.write(data));
             this.updateServerSocket.on('end', () => {
-                logger.info(`Update server connection closed.`);
+                logger.info('Update server connection closed.');
             });
             this.updateServerSocket.on('error', () => {
-                logger.error(`Update server error.`);
+                logger.error('Update server error.');
             });
             this.updateServerSocket.setNoDelay(true);
             this.updateServerSocket.setKeepAlive(true);
@@ -65,13 +65,13 @@ export class GatewayServer extends SocketServer {
                 this.parseLoginServerResponse(new ByteBuffer(data));
             });
             this.loginServerSocket.on('end', () => {
-                logger.error(`Login server error.`);
+                logger.error('Login server error.');
             });
             this.loginServerSocket.setNoDelay(true);
             this.loginServerSocket.setKeepAlive(true);
             this.loginServerSocket.setTimeout(30000);
         } else {
-            logger.error(`Invalid initial client handshake packet id.`);
+            logger.error('Invalid initial client handshake packet id.');
             return false;
         }
 


### PR DESCRIPTION
Unused code is smelly and can at times be confusing or misleading.

This PR turns on all the lint rules against unused code available in Biome and applies fixes across the codebase.